### PR TITLE
Add note post: New text-first site and search are live

### DIFF
--- a/_src/feed/new-text-first-site-and-search-are-live.md
+++ b/_src/feed/new-text-first-site-and-search-are-live.md
@@ -1,0 +1,12 @@
+---
+title: New text-first site and search are live
+post_type: note
+published_date: "2025-08-11 20:57 -05:00"
+tags: ["plaintext", "indieweb", "website"]
+---
+
+Just iterated on another version of the website. 
+
+The major change is that there's now a text-first version of the website for minimal and resource-constrained environments over at [/text](/text)
+
+I've also added search functionality, which you can find at [/search](/search)


### PR DESCRIPTION
## New Note Post

**Title:** New text-first site and search are live
**Type:** note
**File:** `_src/feed/new-text-first-site-and-search-are-live.md`

### Content Preview
Just iterated on another version of the website. 

The major change is that there's now a text-first version of the website for minimal and resource-constrained environments over at [/text](/text)

I'...

### Frontmatter Validation
- ✅ Title: New text-first site and search are live
- ✅ Type: note
- ✅ Tags: plaintext, indieweb, website

**Created via Discord Publishing Bot**