### PR TITLE
Add note post: Webmentions are back

### DIFF
--- a/_src/notes/webmentions-are-back.md
+++ b/_src/notes/webmentions-are-back.md
@@ -1,0 +1,10 @@
+---
+title: Webmentions are back
+post_type: note
+published_date: "2025-08-21 19:15 -05:00"
+tags: ["indieweb", "webmention", "socialweb"]
+---
+
+Nice to see my GitHub Actions back to green after fixing my script to send webmentions. 
+
+Now to discover more amazing content I can link out to.


### PR DESCRIPTION
## New Note Post

**Title:** Webmentions are back
**Type:** note
**File:** `_src/notes/webmentions-are-back.md`

### Content Preview
Nice to see my GitHub Actions back to green after fixing my script to send webmentions. 

Now to discover more amazing content I can link out to.

### Frontmatter Validation
- ✅ Title: Webmentions are back
- ✅ Type: note
- ✅ Tags: indieweb, webmention, socialweb

**Created via Discord Publishing Bot**