### PR TITLE
Add response post: Notes on why blogging lost to Twitter

### DIFF
--- a/_src/responses/notes-why-blogging-lost-twitter-winer.md
+++ b/_src/responses/notes-why-blogging-lost-twitter-winer.md
@@ -1,0 +1,16 @@
+---
+title: Notes on why blogging lost to Twitter
+targeturl: "http://scripting.com/2025/09/09/114446.html?title=bulletPointsFromYesterdaysPodcast"
+response_type: reshare
+dt_published: "2025-09-12 21:16 -05:00"
+dt_updated: "2025-09-12 21:16 -05:00"
+tags: ["blog", "indieweb", "feed", "rss", "blogosphere"]
+---
+
+I haven't listened to the [podcast](https://shownotes.scripting.com/scripting/2025/09/08/whyBloggingLostToTwitterAndOtherFolkSongs.html) yet but there's a lot of good points.
+
+> Subscribing in feed readers required too many steps: copying URLs, menus, pasting, confirming.
+
+> Blogging lost to Twitter because Twitter had one-click subscribe.
+
+> Rebooting the blogosphere requires cooperation and a universal "follow" button.


### PR DESCRIPTION
## New Response Post

**Title:** Notes on why blogging lost to Twitter
**Type:** response
**File:** `_src/responses/notes-why-blogging-lost-twitter-winer.md`

### Content Preview
I haven't listened to the [podcast](https://shownotes.scripting.com/scripting/2025/09/08/whyBloggingLostToTwitterAndOtherFolkSongs.html) yet but there's a lot of good points.

> Subscribing in feed re...

### Frontmatter Validation
- ✅ Title: Notes on why blogging lost to Twitter
- ✅ Type: response
- ✅ Tags: blog, indieweb, feed, rss, blogosphere

**Created via Discord Publishing Bot**