### PR TITLE
Getting-there-apis

### DIFF
--- a/api/notes/function.json
+++ b/api/notes/function.json
@@ -6,7 +6,7 @@
       "direction": "in",
       "name": "req",
       "methods": ["get"],
-      "route": "notes/{*notePath}"
+      "route": "notes/{*path}"
     },
     {
       "type": "http",

--- a/api/notes/index.js
+++ b/api/notes/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = async function (context, req) {
     try {
         // Extract note ID from route parameter
-        const noteId = context.bindingData.notePath;
+        const noteId = context.bindingData.path;
         
         if (!noteId || !noteId.match(/^[a-f0-9]{32}$/)) {
             context.res = {

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -30,7 +30,7 @@
     },
     {
       "route": "/activitypub/notes/*",
-      "rewrite": "/api/notes/{*}"
+      "rewrite": "/api/notes/*"
     },
     {
       "route": "/github",

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -30,7 +30,7 @@
     },
     {
       "route": "/activitypub/notes/*",
-      "rewrite": "/api/notes"
+      "rewrite": "/api/notes/{*}"
     },
     {
       "route": "/github",


### PR DESCRIPTION
- Update Azure Function to use {*path} parameter to capture full wildcard route
- Update JavaScript to extract note ID from path parameter instead of specific binding
- This should properly handle requests from /activitypub/notes/[id] -> /api/notes/[id]