### PR TITLE
Add native Web Share API support

### DIFF
--- a/Views/ComponentViews.fs
+++ b/Views/ComponentViews.fs
@@ -72,11 +72,12 @@ let copyPermalinkButton (relativeUrl: string) =
     ]
 
 /// Generate web share button for sharing via native share
-let webShareButton () =
+let webShareButton (relativeUrl: string) =
     button [
         _class "web-share-btn btn btn-sm btn-outline-secondary ms-2"
         _type "button"
         _title "Share via Web Share API"
+        attr "data-url" relativeUrl
         attr "aria-label" "Share this page"
     ] [
         tag "i" [_class "bi bi-share"; attr "aria-hidden" "true"] []
@@ -94,7 +95,7 @@ let cardFooter (contentType:string) (fileName:string) (tags: string array)=
             Text "Permalink: "
             a [_href permalink; _class "u-url"] [Text $"{permalink}"]
             copyPermalinkButton permalink
-            webShareButton ()
+            webShareButton permalink
         ]
         
         div [] [

--- a/_src/js/main.js
+++ b/_src/js/main.js
@@ -295,12 +295,13 @@ function setupWebShare() {
     document.querySelectorAll('.web-share-btn').forEach(button => {
         button.addEventListener('click', async (e) => {
             e.preventDefault();
-            await shareCurrentPage();
+            const relativeUrl = button.dataset.url;
+            await shareContent(relativeUrl);
         });
     });
 }
 
-async function shareCurrentPage() {
+async function shareContent(relativeUrl) {
     try {
         // Get the page title
         const title = document.title;
@@ -312,8 +313,8 @@ async function shareCurrentPage() {
         // Use selected text or default message
         const text = selectedText || 'I found this interesting';
 
-        // Get current page URL
-        const url = window.location.href;
+        // Build full URL from relative URL
+        const url = relativeUrl ? window.location.origin + relativeUrl : window.location.href;
 
         // Share using Web Share API
         await navigator.share({
@@ -329,4 +330,9 @@ async function shareCurrentPage() {
             console.warn('Error sharing:', err);
         }
     }
+}
+
+async function shareCurrentPage() {
+    // Share the current page without a specific URL (uses window.location.href)
+    await shareContent(null);
 }


### PR DESCRIPTION
Implements Web Share API functionality to allow users to share content from the website using the browser's native share functionality.

Features:
- Detects and shares highlighted/selected text
- Falls back to "I found this interesting" when no text is selected
- Includes page title and URL in all shares
- Adds keyboard shortcut (Ctrl/Cmd + Shift + S) for quick sharing
- Adds share button next to copy permalink button on content cards
- Progressive enhancement: only activates if browser supports Web Share API

Changes:
- _src/js/main.js: Added setupWebShare() and shareCurrentPage() functions
- Views/ComponentViews.fs: Added webShareButton() component and integrated it into cardFooter alongside the existing copy permalink button

🤖 Generated with [Claude Code](https://claude.com/claude-code)