### PR TITLE
fix: Add RSVP support to unified feed timeline filtering

### DIFF
--- a/Views/LayoutViews.fs
+++ b/Views/LayoutViews.fs
@@ -160,7 +160,7 @@ let timelineHomeViewStratified (initialItems: GenericBuilder.UnifiedFeeds.Unifie
                         | "streams" -> $"/streams/{fileName}/"
                         | "media" -> $"/media/{fileName}/"
                         // Specific response types also route to /responses/
-                        | "star" | "reply" | "reshare" -> $"/responses/{fileName}/"
+                        | "star" | "reply" | "reshare" | "rsvp" -> $"/responses/{fileName}/"
                         | "bookmark" -> $"/bookmarks/{fileName}/"
                         | _ -> $"/{contentType}/{fileName}/"
                     
@@ -204,6 +204,7 @@ let timelineHomeViewStratified (initialItems: GenericBuilder.UnifiedFeeds.Unifie
                                           | "star" -> "Star"
                                           | "reply" -> "Reply"
                                           | "reshare" -> "Reshare"
+                                          | "rsvp" -> "RSVP"
                                           | "bookmark" -> "Bookmark"
                                           | _ -> item.ContentType)
                                 ]
@@ -397,7 +398,7 @@ let timelineHomeView (items: GenericBuilder.UnifiedFeeds.UnifiedFeedItem array) 
                         | "streams" -> $"/streams/{fileName}/"
                         | "media" -> $"/media/{fileName}/"
                         // Specific response types also route to /responses/
-                        | "star" | "reply" | "reshare" -> $"/responses/{fileName}/"
+                        | "star" | "reply" | "reshare" | "rsvp" -> $"/responses/{fileName}/"
                         | "bookmark" -> $"/bookmarks/{fileName}/"
                         | _ -> $"/{contentType}/{fileName}/"
                     
@@ -431,6 +432,7 @@ let timelineHomeView (items: GenericBuilder.UnifiedFeeds.UnifiedFeedItem array) 
                                           | "star" -> "Star"
                                           | "reply" -> "Reply"
                                           | "reshare" -> "Reshare"
+                                          | "rsvp" -> "RSVP"
                                           | "bookmark" -> "Bookmark"
                                           | _ -> item.ContentType)
                                 ]

--- a/_src/js/timeline-new.js
+++ b/_src/js/timeline-new.js
@@ -42,7 +42,7 @@ const TimelineFilter = {
                 shouldShow = true;
             } else if (contentType === 'responses') {
                 // Show all response subtypes for "responses" filter
-                shouldShow = ['star', 'reply', 'reshare', 'responses'].includes(cardType);
+                shouldShow = ['star', 'reply', 'reshare', 'rsvp', 'responses'].includes(cardType);
             } else {
                 // Exact match for other content types
                 shouldShow = (contentType === cardType);
@@ -527,7 +527,7 @@ const TimelineProgressiveLoader = {
                 shouldShow = true;
             } else if (filterType === 'responses') {
                 // Show all response subtypes for "responses" filter
-                shouldShow = ['star', 'reply', 'reshare', 'responses'].includes(cardType);
+                shouldShow = ['star', 'reply', 'reshare', 'rsvp', 'responses'].includes(cardType);
             } else {
                 // Exact match for other content types
                 shouldShow = (filterType === cardType);

--- a/_src/js/timeline.js
+++ b/_src/js/timeline.js
@@ -42,7 +42,7 @@ const TimelineFilter = {
                 shouldShow = true;
             } else if (contentType === 'responses') {
                 // Show all response subtypes for "responses" filter
-                shouldShow = ['star', 'reply', 'reshare', 'responses'].includes(cardType);
+                shouldShow = ['star', 'reply', 'reshare', 'rsvp', 'responses'].includes(cardType);
             } else {
                 // Exact match for other content types
                 shouldShow = (contentType === cardType);
@@ -559,7 +559,7 @@ const TimelineProgressiveLoader = {
                 shouldShow = true;
             } else if (filterType === 'responses') {
                 // Show all response subtypes for "responses" filter
-                shouldShow = ['star', 'reply', 'reshare', 'responses'].includes(cardType);
+                shouldShow = ['star', 'reply', 'reshare', 'rsvp', 'responses'].includes(cardType);
             } else {
                 // Exact match for other content types
                 shouldShow = (filterType === cardType);


### PR DESCRIPTION
## Summary

Follow-up fix for PR #2041 (RSVP implementation). RSVPs were correctly showing in the `/responses/` list page but were missing from the homepage unified feed timeline.

## Root Cause

The `rsvp` content type was not included in the JavaScript filter arrays or F# badge/permalink mappings that handle response types in the timeline view.

## Changes

### JavaScript (`timeline.js` and `timeline-new.js`)
- Added `'rsvp'` to the responses filter array in `filterContent()` and `applyFilterToNewContent()` functions
- Filter now includes: `['star', 'reply', 'reshare', 'rsvp', 'responses']`

### F# (`Views/LayoutViews.fs`)
- Added `'rsvp' -> "RSVP"` badge mapping in both stratified and non-stratified timeline views
- Added `'rsvp'` to the response permalink routing pattern (routes to `/responses/{fileName}/`)

## Testing

- ✅ Build succeeds
- ✅ FOSDEM 2026 RSVP now appears in homepage with correct `data-type="rsvp"` attribute
- ✅ RSVP badge displays as "RSVP" 
- ✅ Clicking "Responses" filter will show RSVPs along with stars, replies, and reshares
- ✅ Links correctly route to `/responses/` path

## Related

Fixes follow-up issue from #2041 - RSVPs now appear in unified feed timeline when filtering by 'All' or 'Responses'.