### PR TITLE
feat: LLM entity extraction & RDF serialization pipeline

### DIFF
--- a/Builder.fs
+++ b/Builder.fs
@@ -975,10 +975,20 @@ module Builder
         // Build knowledge graph from all entries
         let allEntries = feedData |> List.map (fun item -> item.Content) |> List.toArray
         let slugToTitle = allEntries |> Array.map (fun e -> e.FileName, e.Metadata.Title) |> Map.ofArray
-        let graph = KnowledgeGraph.buildGraph allEntries
+        
+        // Entity extraction (uses cache; no-op without GITHUB_TOKEN)
+        let chatClient = EntityExtraction.createChatClient ()
+        let entryPairs = allEntries |> Array.map (fun e -> (e.FileName, e.Content))
+        let extractions =
+            EntityExtraction.extractAll chatClient entryPairs "https://www.lqdev.me"
+        
+        let graph = KnowledgeGraph.buildGraph allEntries extractions
         
         // Save graph.json
         KnowledgeGraph.saveGraphJson outputDir graph |> ignore
+        
+        // Serialize RDF (Turtle + JSON-LD)
+        RdfSerializer.serializeGraph graph outputDir |> ignore
         
         // Generate individual pages
         feedData
@@ -1006,13 +1016,18 @@ module Builder
             let relatedEntries = 
                 Map.tryFind entry.FileName graph.RelatedEntries 
                 |> Option.defaultValue [||]
-            let jsonLd = KnowledgeGraph.generateEntryJsonLd entry graph
+            let jsonLd = KnowledgeGraph.generateEntryJsonLd entry graph extractions
             
             // Find cross-content-type related items
             let crossContent =
                 KnowledgeGraph.findCrossContentRelated entryTags entry.FileName crossContentItems
             
-            let html = LayoutViews.aiMemexPageView entry.Metadata.Title (contentToRender |> convertMdToHtml) entry.Metadata.PublishedDate entry.Metadata.LastUpdatedDate entry.FileName entryTags entry.Metadata.EntryType entry.Metadata.Description entry.Metadata.RelatedSkill entry.Metadata.SourceProject backlinks relatedEntries jsonLd crossContent
+            // Get entity nodes for this entry
+            let entryEntityNodes =
+                graph.EntityNodes
+                |> Array.filter (fun en -> en.MentionedIn |> Array.contains entry.FileName)
+            
+            let html = LayoutViews.aiMemexPageView entry.Metadata.Title (contentToRender |> convertMdToHtml) entry.Metadata.PublishedDate entry.Metadata.LastUpdatedDate entry.FileName entryTags entry.Metadata.EntryType entry.Metadata.Description entry.Metadata.RelatedSkill entry.Metadata.SourceProject backlinks relatedEntries jsonLd crossContent entryEntityNodes
             let page = generate html "defaultindex" $"{entry.Metadata.Title} | AI Memex | Luis Quintanilla"
             let saveFileName = Path.Join(saveDir, "index.html")
             File.WriteAllText(saveFileName, page))

--- a/EntityExtraction.fs
+++ b/EntityExtraction.fs
@@ -27,6 +27,20 @@ type ExtractionResult = {
     [<JsonPropertyName("assertions")>] Assertions: Assertion array
 }
 
+// --- Normalization ---
+
+/// Strip schema: prefix from entity types for consistent downstream matching
+let private normalizeEntityType (t: string) =
+    if String.IsNullOrWhiteSpace(t) then "Thing"
+    elif t.StartsWith("schema:", StringComparison.OrdinalIgnoreCase) then t.Substring(7)
+    else t
+
+let private normalizeResult (result: ExtractionResult) =
+    { result with
+        Entities =
+            result.Entities
+            |> Array.map (fun e -> { e with EntityType = normalizeEntityType e.EntityType }) }
+
 // --- Cache ---
 
 let private cacheDir = Path.Combine("graph", "cache")
@@ -45,7 +59,9 @@ let private loadCache (slug: string) : ExtractionResult option =
     if File.Exists(path) then
         try
             let json = File.ReadAllText(path)
-            Some (JsonSerializer.Deserialize<ExtractionResult>(json, jsonOptions))
+            JsonSerializer.Deserialize<ExtractionResult>(json, jsonOptions)
+            |> Option.ofObj
+            |> Option.map normalizeResult
         with _ -> None
     else None
 
@@ -181,7 +197,7 @@ let extractEntities
                             eprintfn "Warning: extraction failed for %s: %s" slug ex.Message
                             emptyResult)
 
-            let merged = mergeResults results
+            let merged = mergeResults results |> normalizeResult
             if merged.Entities.Length > 0 then
                 saveCache slug merged
             merged

--- a/EntityExtraction.fs
+++ b/EntityExtraction.fs
@@ -1,0 +1,214 @@
+module EntityExtraction
+
+open System
+open System.IO
+open System.Text.Json
+open System.Text.Json.Serialization
+open Microsoft.Extensions.AI
+
+// --- Extraction result types ---
+
+type ExtractedEntity = {
+    [<JsonPropertyName("id")>] Id: string
+    [<JsonPropertyName("type")>] EntityType: string
+    [<JsonPropertyName("label")>] Label: string
+    [<JsonPropertyName("sameAs")>] SameAs: string array
+}
+
+type Assertion = {
+    [<JsonPropertyName("s")>] Subject: string
+    [<JsonPropertyName("p")>] Predicate: string
+    [<JsonPropertyName("o")>] Object: string
+    [<JsonPropertyName("confidence")>] Confidence: float
+}
+
+type ExtractionResult = {
+    [<JsonPropertyName("entities")>] Entities: ExtractedEntity array
+    [<JsonPropertyName("assertions")>] Assertions: Assertion array
+}
+
+// --- Cache ---
+
+let private cacheDir = Path.Combine("graph", "cache")
+let private promptVersion = "v1"
+
+let private cachePath (slug: string) =
+    Path.Combine(cacheDir, $"{slug}.{promptVersion}.json")
+
+let private jsonOptions =
+    let opts = JsonSerializerOptions(WriteIndented = true)
+    opts.DefaultIgnoreCondition <- JsonIgnoreCondition.WhenWritingNull
+    opts
+
+let private loadCache (slug: string) : ExtractionResult option =
+    let path = cachePath slug
+    if File.Exists(path) then
+        try
+            let json = File.ReadAllText(path)
+            Some (JsonSerializer.Deserialize<ExtractionResult>(json, jsonOptions))
+        with _ -> None
+    else None
+
+let private saveCache (slug: string) (result: ExtractionResult) =
+    Directory.CreateDirectory(cacheDir) |> ignore
+    let json = JsonSerializer.Serialize(result, jsonOptions)
+    File.WriteAllText(cachePath slug, json)
+
+// --- Markdown chunking ---
+
+/// Split markdown body into chunks by top-level headings, targeting ~750 tokens.
+/// Returns (chunkIndex, chunkText) pairs.
+let chunkMarkdown (bodyText: string) : (int * string) array =
+    if String.IsNullOrWhiteSpace(bodyText) then [||]
+    else
+        let lines = bodyText.Split([| '\n' |])
+        let mutable chunks = []
+        let mutable currentChunk = System.Text.StringBuilder()
+        let mutable chunkIndex = 0
+
+        for line in lines do
+            if line.StartsWith("## ") && currentChunk.Length > 100 then
+                chunks <- (chunkIndex, currentChunk.ToString().Trim()) :: chunks
+                chunkIndex <- chunkIndex + 1
+                currentChunk <- System.Text.StringBuilder()
+            currentChunk.AppendLine(line) |> ignore
+
+        if currentChunk.Length > 0 then
+            chunks <- (chunkIndex, currentChunk.ToString().Trim()) :: chunks
+
+        chunks |> List.rev |> List.toArray
+
+// --- IChatClient creation ---
+
+/// Create an IChatClient targeting GitHub Models via MEAI.
+/// Returns None if GITHUB_TOKEN is not set (graceful degradation).
+let createChatClient () : IChatClient option =
+    let token = Environment.GetEnvironmentVariable("GITHUB_TOKEN")
+    if String.IsNullOrEmpty(token) then
+        None
+    else
+        try
+            let credential = System.ClientModel.ApiKeyCredential(token)
+            let options = OpenAI.OpenAIClientOptions()
+            options.Endpoint <- Uri("https://models.github.ai/inference")
+            let openAiClient = OpenAI.OpenAIClient(credential, options)
+            let chatClient =
+                openAiClient
+                    .GetChatClient("openai/gpt-4o-mini")
+                    .AsIChatClient()
+            Some chatClient
+        with ex ->
+            eprintfn "Warning: Failed to create LLM client: %s" ex.Message
+            None
+
+// --- Extraction ---
+
+let private emptyResult = { Entities = [||]; Assertions = [||] }
+
+let private promptPath = Path.Combine("ontology", "extract_entities_v1.txt")
+
+/// Load the system prompt, substituting the article URI placeholder.
+let private loadSystemPrompt () : string =
+    if File.Exists(promptPath) then
+        File.ReadAllText(promptPath)
+    else
+        failwithf "Extraction prompt not found: %s" promptPath
+
+/// Extract entities from a single chunk using MEAI structured output.
+let private extractFromChunk
+    (client: IChatClient)
+    (systemPrompt: string)
+    (articleUri: string)
+    (chunkText: string)
+    : ExtractionResult =
+    let prompt = systemPrompt.Replace("<ARTICLE_URI>", articleUri)
+    let messages = [
+        ChatMessage(ChatRole.System, prompt)
+        ChatMessage(ChatRole.User, chunkText)
+    ]
+    let options = ChatOptions()
+    options.ResponseFormat <- ChatResponseFormat.ForJsonSchema<ExtractionResult>()
+
+    let response =
+        client.GetResponseAsync(messages, options)
+        |> Async.AwaitTask
+        |> Async.RunSynchronously
+
+    let text = response.Text
+    if String.IsNullOrWhiteSpace(text) then emptyResult
+    else
+        try
+            JsonSerializer.Deserialize<ExtractionResult>(text, jsonOptions)
+        with _ -> emptyResult
+
+/// Merge multiple extraction results, deduplicating entities by id.
+let private mergeResults (results: ExtractionResult array) : ExtractionResult =
+    let entities =
+        results
+        |> Array.collect (fun r -> r.Entities)
+        |> Array.distinctBy (fun e -> e.Id.ToLowerInvariant())
+    let assertions =
+        results
+        |> Array.collect (fun r -> r.Assertions)
+        |> Array.distinctBy (fun a -> (a.Subject, a.Predicate, a.Object))
+    { Entities = entities; Assertions = assertions }
+
+/// Extract entities from a Memex entry. Uses cache when available.
+/// Without an IChatClient, returns cached results or empty.
+let extractEntities
+    (chatClient: IChatClient option)
+    (slug: string)
+    (bodyText: string)
+    (baseUrl: string)
+    : ExtractionResult =
+    match loadCache slug with
+    | Some cached -> cached
+    | None ->
+        match chatClient with
+        | None -> emptyResult
+        | Some client ->
+            let systemPrompt = loadSystemPrompt ()
+            let articleUri = $"{baseUrl}/resources/ai-memex/{slug}/"
+            let chunks = chunkMarkdown bodyText
+
+            let results =
+                if chunks.Length = 0 then [| emptyResult |]
+                else
+                    chunks
+                    |> Array.map (fun (_, chunkText) ->
+                        try extractFromChunk client systemPrompt articleUri chunkText
+                        with ex ->
+                            eprintfn "Warning: extraction failed for %s: %s" slug ex.Message
+                            emptyResult)
+
+            let merged = mergeResults results
+            if merged.Entities.Length > 0 then
+                saveCache slug merged
+            merged
+
+/// Extract entities for all entries, logging progress.
+let extractAll
+    (chatClient: IChatClient option)
+    (entries: (string * string) array)
+    (baseUrl: string)
+    : Map<string, ExtractionResult> =
+    let total = entries.Length
+    let mutable cacheHits = 0
+    let mutable llmCalls = 0
+
+    let results =
+        entries
+        |> Array.mapi (fun i (slug, body) ->
+            let isCached = (loadCache slug).IsSome
+            if isCached then cacheHits <- cacheHits + 1
+            else if chatClient.IsSome then llmCalls <- llmCalls + 1
+
+            if (i + 1) % 10 = 0 || i = total - 1 then
+                eprintfn "  Entity extraction: %d/%d (cache: %d, LLM: %d)" (i + 1) total cacheHits llmCalls
+
+            let result = extractEntities chatClient slug body baseUrl
+            (slug, result))
+        |> Map.ofArray
+
+    eprintfn "  Entity extraction complete: %d entries, %d cached, %d LLM calls" total cacheHits llmCalls
+    results

--- a/KnowledgeGraph.fs
+++ b/KnowledgeGraph.fs
@@ -15,6 +15,7 @@ type EdgeType =
     | TagOverlap
     | SameProject
     | SameEntryTypeTag
+    | EntityMention
 
 type GraphNode = {
     Id: string
@@ -56,11 +57,20 @@ type CrossContentItem = {
     OverlapReason: string
 }
 
+type EntityNode = {
+    Id: string
+    Label: string
+    EntityType: string
+    SameAs: string array
+    MentionedIn: string array
+}
+
 type KnowledgeGraph = {
     Nodes: GraphNode array
     Edges: GraphEdge array
     Backlinks: Map<string, BacklinkData array>
     RelatedEntries: Map<string, RelatedEntryData array>
+    EntityNodes: EntityNode array
 }
 
 // --- Helpers ---
@@ -289,11 +299,49 @@ let private computeRelatedEntries (nodes: GraphNode array) (edges: GraphEdge arr
                 }
             | None -> None))
 
-/// Build the complete knowledge graph from AI Memex entries
-let buildGraph (entries: AiMemex array) : KnowledgeGraph =
+/// Layer 6: Entity mentions from LLM extraction (weight ~0.8)
+let private extractEntityMentionEdges (extractions: Map<string, EntityExtraction.ExtractionResult>) : GraphEdge array =
+    extractions
+    |> Map.toArray
+    |> Array.collect (fun (entrySlug, result) ->
+        result.Assertions
+        |> Array.choose (fun a ->
+            if a.Predicate = "schema:mentions" && a.Confidence >= 0.5 then
+                let entitySlug = 
+                    a.Object.Replace("https://www.lqdev.me/entity/", "entity:")
+                Some {
+                    Source = entrySlug
+                    Target = entitySlug
+                    EdgeType = EntityMention
+                    Weight = min (a.Confidence * 0.9) 0.85
+                    Reason = sprintf "mentions entity"
+                }
+            else None))
+
+/// Build entity nodes from extraction results
+let private buildEntityNodes (extractions: Map<string, EntityExtraction.ExtractionResult>) : EntityNode array =
+    let mutable entityMap: Map<string, EntityNode> = Map.empty
+    for KeyValue(entrySlug, result) in extractions do
+        for entity in result.Entities do
+            let normalId = entity.Id.ToLowerInvariant()
+            match Map.tryFind normalId entityMap with
+            | Some existing ->
+                let updated = { existing with MentionedIn = Array.append existing.MentionedIn [| entrySlug |] |> Array.distinct }
+                entityMap <- Map.add normalId updated entityMap
+            | None ->
+                entityMap <- Map.add normalId {
+                    Id = entity.Id
+                    Label = entity.Label
+                    EntityType = entity.EntityType
+                    SameAs = if isNull entity.SameAs then [||] else entity.SameAs
+                    MentionedIn = [| entrySlug |]
+                } entityMap
+    entityMap |> Map.values |> Seq.toArray
+
+/// Build the complete knowledge graph from AI Memex entries and optional entity extractions
+let buildGraph (entries: AiMemex array) (extractions: Map<string, EntityExtraction.ExtractionResult>) : KnowledgeGraph =
     let nodes = entries |> Array.map toGraphNode
     
-    // Collect edges from all layers
     let allEdges =
         [|
             yield! extractExplicitEdges entries
@@ -301,13 +349,15 @@ let buildGraph (entries: AiMemex array) : KnowledgeGraph =
             yield! extractTagOverlapEdges entries
             yield! extractSameProjectEdges entries
             yield! extractSameTypeTagEdges entries
+            yield! extractEntityMentionEdges extractions
         |]
     
     let edges = deduplicateEdges allEdges
     let backlinks = computeBacklinks nodes edges
     let relatedEntries = computeRelatedEntries nodes edges
+    let entityNodes = buildEntityNodes extractions
     
-    { Nodes = nodes; Edges = edges; Backlinks = backlinks; RelatedEntries = relatedEntries }
+    { Nodes = nodes; Edges = edges; Backlinks = backlinks; RelatedEntries = relatedEntries; EntityNodes = entityNodes }
 
 // --- JSON-LD Generation ---
 
@@ -322,7 +372,7 @@ let private schemaOrgType (entryType: string) =
     | _ -> "Article"
 
 /// Generate JSON-LD for a single AI Memex entry page
-let generateEntryJsonLd (entry: AiMemex) (graph: KnowledgeGraph) : string =
+let generateEntryJsonLd (entry: AiMemex) (graph: KnowledgeGraph) (extractions: Map<string, EntityExtraction.ExtractionResult>) : string =
     let relatedLinks =
         match Map.tryFind entry.FileName graph.RelatedEntries with
         | Some related -> 
@@ -354,6 +404,25 @@ let generateEntryJsonLd (entry: AiMemex) (graph: KnowledgeGraph) : string =
             sprintf ""","about":[%s]""" (String.Join(",", aboutItems))
         else ""
     
+    // Generate schema:mentions from extracted entities
+    let mentionsJson =
+        match Map.tryFind entry.FileName extractions with
+        | Some result when result.Entities.Length > 0 ->
+            let mentionItems =
+                result.Entities
+                |> Array.map (fun entity ->
+                    let sameAsJson =
+                        if isNull entity.SameAs || entity.SameAs.Length = 0 then ""
+                        else
+                            let links = entity.SameAs |> Array.map (fun s -> sprintf "\"%s\"" (jsonEscape s))
+                            sprintf ""","sameAs":[%s]""" (String.Join(",", links))
+                    sprintf """{"@type":"%s","name":"%s"%s}""" 
+                        (jsonEscape entity.EntityType)
+                        (jsonEscape entity.Label) 
+                        sameAsJson)
+            sprintf ""","mentions":[%s]""" (String.Join(",", mentionItems))
+        | _ -> ""
+
     let keywords = String.Join(",", tags)
     
     sprintf """{
@@ -367,7 +436,7 @@ let generateEntryJsonLd (entry: AiMemex) (graph: KnowledgeGraph) : string =
   "datePublished":"%s",
   "dateModified":"%s",
   "keywords":"%s",
-  "isPartOf":{"@type":"Collection","@id":"https://www.lqdev.me/resources/ai-memex/","name":"AI Memex"}%s%s,
+  "isPartOf":{"@type":"Collection","@id":"https://www.lqdev.me/resources/ai-memex/","name":"AI Memex"}%s%s%s,
   "mainEntityOfPage":{"@type":"WebPage","@id":"https://www.lqdev.me/resources/ai-memex/%s/"}
 }"""     (schemaOrgType entry.Metadata.EntryType)
          entry.FileName
@@ -378,6 +447,7 @@ let generateEntryJsonLd (entry: AiMemex) (graph: KnowledgeGraph) : string =
          keywords
          relatedLinkJson
          aboutJson
+         mentionsJson
          entry.FileName
 
 /// Generate CollectionPage JSON-LD for the AI Memex index page
@@ -422,6 +492,7 @@ let serializeGraphJson (graph: KnowledgeGraph) : string =
         | TagOverlap -> "tag-overlap"
         | SameProject -> "same-project"
         | SameEntryTypeTag -> "same-type-tag"
+        | EntityMention -> "entity-mention"
     
     let connectionCounts =
         let mutable counts: Map<string, int> = Map.empty
@@ -457,9 +528,17 @@ let serializeGraphJson (graph: KnowledgeGraph) : string =
         if graph.Nodes.Length = 0 then 0.0
         else (graph.Edges.Length |> float) * 2.0 / (graph.Nodes.Length |> float)
     
+    let entityNodes =
+        graph.EntityNodes
+        |> Array.map (fun en ->
+            {| id = en.Id; label = en.Label; entityType = en.EntityType
+               sameAs = en.SameAs; mentionedIn = en.MentionedIn |})
+    
     let graphDto =
         {| nodes = nodes; edges = edges; clusters = clusters
+           entities = entityNodes
            stats = {| nodeCount = graph.Nodes.Length; edgeCount = graph.Edges.Length
+                      entityCount = graph.EntityNodes.Length
                       avgConnections = Math.Round(avgConn, 1); generatedAt = now |} |}
     
     let options = JsonSerializerOptions(WriteIndented = false)

--- a/KnowledgeGraph.fs
+++ b/KnowledgeGraph.fs
@@ -265,7 +265,10 @@ let private computeRelatedEntries (nodes: GraphNode array) (edges: GraphEdge arr
     let nodeMap = nodes |> Array.map (fun n -> n.Id, n) |> Map.ofArray
     let mutable scores: Map<string, Map<string, (float * string)>> = Map.empty
     
-    for edge in edges do
+    // Exclude entity-mention edges — their targets aren't entry nodes
+    let entryEdges = edges |> Array.filter (fun e -> e.EdgeType <> EntityMention)
+    
+    for edge in entryEdges do
         // Accumulate score from source's perspective toward target
         let updateScore (fromId: string) (toId: string) =
             let current = 
@@ -307,11 +310,9 @@ let private extractEntityMentionEdges (extractions: Map<string, EntityExtraction
         result.Assertions
         |> Array.choose (fun a ->
             if a.Predicate = "schema:mentions" && a.Confidence >= 0.5 then
-                let entitySlug = 
-                    a.Object.Replace("https://www.lqdev.me/entity/", "entity:")
                 Some {
                     Source = entrySlug
-                    Target = entitySlug
+                    Target = a.Object
                     EdgeType = EntityMention
                     Weight = min (a.Confidence * 0.9) 0.85
                     Reason = sprintf "mentions entity"

--- a/PersonalSite.fsproj
+++ b/PersonalSite.fsproj
@@ -22,7 +22,9 @@
     <Compile Include="Services\FollowersSync.fs" /> 
     <Compile Include="GenericBuilder.fs" />
     <Compile Include="ActivityPubBuilder.fs" />
+    <Compile Include="EntityExtraction.fs" />
     <Compile Include="KnowledgeGraph.fs" />
+    <Compile Include="RdfSerializer.fs" />
     <Compile Include="Views\ComponentViews.fs" />
     <Compile Include="Views\TagViews.fs" />
     <Compile Include="Views\FeedViews.fs" />
@@ -43,10 +45,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="dotNetRdf" Version="3.*" />
     <PackageReference Include="FSharp.Data" Version="5.0.2" />
     <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
     <PackageReference Include="lqdev.WebmentionFs" Version="0.0.7" />
     <PackageReference Include="Markdig" Version="0.38.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.4.*" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.*" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/RdfSerializer.fs
+++ b/RdfSerializer.fs
@@ -71,7 +71,12 @@ let serializeGraph (graph: KnowledgeGraph) (outputDir: string) =
 
     // Entity nodes and mentions edges
     for entity in graph.EntityNodes do
-        let entityUri = rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me/entity/{entity.Id}"))
+        let isAbsolute, parsedUri = Uri.TryCreate(entity.Id, UriKind.Absolute)
+        let entityUri =
+            if isAbsolute then
+                rdf.CreateUriNode(parsedUri)
+            else
+                rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me/entity/{entity.Id}"))
         let entityRdfType =
             match entity.EntityType with
             | "SoftwareApplication" -> "schema:SoftwareApplication"

--- a/RdfSerializer.fs
+++ b/RdfSerializer.fs
@@ -85,7 +85,7 @@ let serializeGraph (graph: KnowledgeGraph) (outputDir: string) =
             | "Organization" -> "schema:Organization"
             | "WebAPI" -> "schema:WebAPI"
             | "WebApplication" -> "schema:WebApplication"
-            | "ProgrammingLanguage" -> "schema:ComputerLanguage"
+            | "ProgrammingLanguage" | "ComputerLanguage" -> "schema:ComputerLanguage"
             | "CreativeWork" -> "schema:CreativeWork"
             | "Article" -> "schema:Article"
             | _ -> "schema:Thing"

--- a/RdfSerializer.fs
+++ b/RdfSerializer.fs
@@ -1,0 +1,116 @@
+module RdfSerializer
+
+open System
+open System.IO
+open VDS.RDF
+open VDS.RDF.Writing
+open KnowledgeGraph
+
+let private schemaUri = Uri("https://schema.org/")
+let private kbUri = Uri("https://www.lqdev.me/vocab/kb#")
+let private baseUri = Uri("https://www.lqdev.me/")
+
+let inline private assertTriple (g: IGraph) (s: INode) (p: INode) (o: INode) =
+    g.Assert(Triple(s, p, o)) |> ignore
+
+/// Build an RDF graph from the knowledge graph and serialize to Turtle + JSON-LD
+let serializeGraph (graph: KnowledgeGraph) (outputDir: string) =
+    let rdf = new Graph()
+
+    rdf.NamespaceMap.AddNamespace("schema", schemaUri)
+    rdf.NamespaceMap.AddNamespace("kb", kbUri)
+    rdf.NamespaceMap.AddNamespace("rdf", Uri("http://www.w3.org/1999/02/22-rdf-syntax-ns#"))
+    rdf.NamespaceMap.AddNamespace("rdfs", Uri("http://www.w3.org/2000/01/rdf-schema#"))
+    rdf.NamespaceMap.AddNamespace("lqdev", baseUri)
+
+    let rdfType = rdf.CreateUriNode("rdf:type")
+    let schemaName = rdf.CreateUriNode("schema:name")
+    let schemaUrl = rdf.CreateUriNode("schema:url")
+    let schemaMentions = rdf.CreateUriNode("schema:mentions")
+    let schemaKeywords = rdf.CreateUriNode("schema:keywords")
+    let schemaSameAs = rdf.CreateUriNode("schema:sameAs")
+    let kbEntryType = rdf.CreateUriNode("kb:entryType")
+    let kbSourceProject = rdf.CreateUriNode("kb:sourceProject")
+    let kbRelatedTo = rdf.CreateUriNode("kb:relatedTo")
+    let assert3 s p o = assertTriple rdf s p o
+
+    // Entry nodes
+    for node in graph.Nodes do
+        let entryUri = rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me{node.Url}"))
+        let articleType =
+            match node.EntryType with
+            | "pattern" -> "schema:TechArticle"
+            | "research" -> "schema:ScholarlyArticle"
+            | "blog-post" -> "schema:BlogPosting"
+            | _ -> "schema:Article"
+        assert3 entryUri rdfType (rdf.CreateUriNode(articleType))
+        assert3 entryUri schemaName (rdf.CreateLiteralNode(node.Title))
+        assert3 entryUri schemaUrl (rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me{node.Url}")))
+        assert3 entryUri kbEntryType (rdf.CreateLiteralNode(node.EntryType))
+
+        if not (String.IsNullOrWhiteSpace(node.Description)) then
+            assert3 entryUri (rdf.CreateUriNode("schema:description")) (rdf.CreateLiteralNode(node.Description))
+
+        if not (String.IsNullOrWhiteSpace(node.SourceProject)) then
+            assert3 entryUri kbSourceProject (rdf.CreateLiteralNode(node.SourceProject))
+
+        for tag in node.Tags do
+            assert3 entryUri schemaKeywords (rdf.CreateLiteralNode(tag))
+
+    // Edges as kb:relatedTo
+    for edge in graph.Edges do
+        if edge.EdgeType <> EntityMention then
+            let src = graph.Nodes |> Array.tryFind (fun n -> n.Id = edge.Source)
+            let tgt = graph.Nodes |> Array.tryFind (fun n -> n.Id = edge.Target)
+            match src, tgt with
+            | Some s, Some t ->
+                let srcUri = rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me{s.Url}"))
+                let tgtUri = rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me{t.Url}"))
+                assert3 srcUri kbRelatedTo tgtUri
+            | _ -> ()
+
+    // Entity nodes and mentions edges
+    for entity in graph.EntityNodes do
+        let entityUri = rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me/entity/{entity.Id}"))
+        let entityRdfType =
+            match entity.EntityType with
+            | "SoftwareApplication" -> "schema:SoftwareApplication"
+            | "SoftwareSourceCode" -> "schema:SoftwareSourceCode"
+            | "Person" -> "schema:Person"
+            | "Organization" -> "schema:Organization"
+            | "WebAPI" -> "schema:WebAPI"
+            | "WebApplication" -> "schema:WebApplication"
+            | "ProgrammingLanguage" -> "schema:ComputerLanguage"
+            | "CreativeWork" -> "schema:CreativeWork"
+            | "Article" -> "schema:Article"
+            | _ -> "schema:Thing"
+        assert3 entityUri rdfType (rdf.CreateUriNode(entityRdfType))
+        assert3 entityUri schemaName (rdf.CreateLiteralNode(entity.Label))
+
+        for sameAsUrl in entity.SameAs do
+            if not (String.IsNullOrWhiteSpace(sameAsUrl)) then
+                try assert3 entityUri schemaSameAs (rdf.CreateUriNode(UriFactory.Create(sameAsUrl)))
+                with _ -> ()
+
+        for slug in entity.MentionedIn do
+            match graph.Nodes |> Array.tryFind (fun n -> n.Id = slug) with
+            | Some n ->
+                let entryUri = rdf.CreateUriNode(UriFactory.Create($"https://www.lqdev.me{n.Url}"))
+                assert3 entryUri schemaMentions entityUri
+            | None -> ()
+
+    // Serialize to Turtle
+    let outPath = Path.Combine(outputDir, "resources", "ai-memex")
+    Directory.CreateDirectory(outPath) |> ignore
+
+    let turtleWriter = CompressingTurtleWriter()
+    turtleWriter.Save(rdf, Path.Combine(outPath, "graph.ttl"))
+
+    // Serialize to JSON-LD via TripleStore wrapper
+    let store = new TripleStore()
+    store.Add(rdf) |> ignore
+    let jsonLdWriter = JsonLdWriter()
+    jsonLdWriter.Save(store, Path.Combine(outPath, "graph.jsonld"))
+
+    eprintfn "  RDF serialized: %d triples -> graph.ttl + graph.jsonld" rdf.Triples.Count
+    rdf.Triples.Count

--- a/Views/LayoutViews.fs
+++ b/Views/LayoutViews.fs
@@ -934,7 +934,7 @@ let aiMemexPageView (title:string) (content:string) (publishedDate:string) (last
                                     | "Person" -> "bi bi-person"
                                     | "Organization" | "Corporation" -> "bi bi-building"
                                     | "WebAPI" | "WebApplication" -> "bi bi-globe"
-                                    | "ProgrammingLanguage" -> "bi bi-braces"
+                                    | "ProgrammingLanguage" | "ComputerLanguage" -> "bi bi-braces"
                                     | "CreativeWork" | "Article" | "ScholarlyArticle" -> "bi bi-journal-text"
                                     | _ -> "bi bi-tag"
                                 if entity.SameAs.Length > 0 then

--- a/Views/LayoutViews.fs
+++ b/Views/LayoutViews.fs
@@ -774,7 +774,7 @@ let wikiPageView (title:string) (content:string) (date:string) (fileName:string)
         ]
     ]
 
-let aiMemexPageView (title:string) (content:string) (publishedDate:string) (lastUpdatedDate:string) (fileName:string) (tags: string array) (entryType: string) (description: string) (relatedSkill: string) (sourceProject: string) (backlinks: KnowledgeGraph.BacklinkData array) (relatedEntries: KnowledgeGraph.RelatedEntryData array) (jsonLd: string) (crossContent: KnowledgeGraph.CrossContentItem array) = 
+let aiMemexPageView (title:string) (content:string) (publishedDate:string) (lastUpdatedDate:string) (fileName:string) (tags: string array) (entryType: string) (description: string) (relatedSkill: string) (sourceProject: string) (backlinks: KnowledgeGraph.BacklinkData array) (relatedEntries: KnowledgeGraph.RelatedEntryData array) (jsonLd: string) (crossContent: KnowledgeGraph.CrossContentItem array) (entityNodes: KnowledgeGraph.EntityNode array) = 
     let publishDate = DateTimeOffset.Parse(publishedDate)
     let entryTypeIcon = 
         match entryType with
@@ -917,6 +917,36 @@ let aiMemexPageView (title:string) (content:string) (publishedDate:string) (last
                                     a [ _href item.Url ] [ Text item.Title ]
                                     span [ _class "ai-memex-edge-reason" ] [ Text $" — {item.OverlapReason}" ]
                                 ]
+                        ]
+                    ]
+                
+                if entityNodes.Length > 0 then
+                    div [ _class "ai-memex-entities" ] [
+                        h3 [] [
+                            span [ _class "bi bi-diagram-2" ] []
+                            Text " Entities Mentioned"
+                        ]
+                        div [ _class "entity-chips" ] [
+                            for entity in entityNodes do
+                                let iconClass =
+                                    match entity.EntityType with
+                                    | "SoftwareApplication" | "SoftwareSourceCode" -> "bi bi-code-slash"
+                                    | "Person" -> "bi bi-person"
+                                    | "Organization" | "Corporation" -> "bi bi-building"
+                                    | "WebAPI" | "WebApplication" -> "bi bi-globe"
+                                    | "ProgrammingLanguage" -> "bi bi-braces"
+                                    | "CreativeWork" | "Article" | "ScholarlyArticle" -> "bi bi-journal-text"
+                                    | _ -> "bi bi-tag"
+                                if entity.SameAs.Length > 0 then
+                                    a [ _href entity.SameAs.[0]; _class "entity-chip"; _target "_blank"; attr "rel" "noopener"; _title entity.EntityType ] [
+                                        span [ _class iconClass ] []
+                                        Text $" {entity.Label}"
+                                    ]
+                                else
+                                    span [ _class "entity-chip"; _title entity.EntityType ] [
+                                        span [ _class iconClass ] []
+                                        Text $" {entity.Label}"
+                                    ]
                         ]
                     ]
                 

--- a/_src/css/custom/ai-memex.css
+++ b/_src/css/custom/ai-memex.css
@@ -374,3 +374,35 @@
     fill: var(--text-color, #333);
     pointer-events: none;
 }
+
+/* Entity chips on AI Memex entry pages */
+.ai-memex-entities {
+    margin-top: 1.5rem;
+}
+.ai-memex-entities h3 {
+    margin-bottom: 0.75rem;
+    font-size: 1.1rem;
+}
+.entity-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+.entity-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: 1rem;
+    background-color: var(--desert-twilight-bg, #f0f0f5);
+    color: var(--text-color, #333);
+    font-size: 0.85rem;
+    text-decoration: none;
+    border: 1px solid var(--border-color, #ddd);
+    transition: background-color 0.15s;
+}
+a.entity-chip:hover {
+    background-color: var(--desert-twilight, #8b7ec8);
+    color: #fff;
+    text-decoration: none;
+}

--- a/_src/resources/ai-memex/pattern-azure-swa-function-file-isolation.md
+++ b/_src/resources/ai-memex/pattern-azure-swa-function-file-isolation.md
@@ -3,11 +3,11 @@ title: "Pattern: Azure SWA Managed Functions Cannot Access Static Content Files"
 description: "Azure Static Web Apps deploys API functions in an isolated sandbox — they cannot read files from app_location or sibling directories, only their own api_location tree"
 entry_type: pattern
 published_date: "2026-04-04 18:36 +00:00"
-last_updated_date: "2026-04-04 18:36 +00:00"
+last_updated_date: "2026-04-05 00:55 +00:00"
 tags: "azure, architecture, devops, patterns"
 related_skill: ""
 source_project: "markdown-ld-kb"
-related_entries: "pattern-github-models-zero-cost-ci-llm"
+related_entries: "pattern-github-models-zero-cost-ci-llm, pattern-nl-to-sparql-schema-injected-few-shot"
 ---
 
 # Pattern: Azure SWA Managed Functions Cannot Access Static Content Files
@@ -65,3 +65,19 @@ When designing Azure SWA architectures with managed functions:
 - **If a function needs data files, put them inside `api/`** — either checked in or copied during CI
 - **Test with `swa start` locally** — the SWA CLI emulator reproduces this isolation, unlike raw `func start`
 - **Watch for "silent empty"** — the function won't crash if the directory doesn't exist; it just loads zero data, which surfaces as empty query results rather than errors
+
+## Related: Relative Imports Also Fail
+
+A second gotcha in the same environment: **relative Python imports don't work** in Azure SWA managed functions.
+
+```python
+# This crashes the function app at startup (silent 404 on all endpoints):
+from .nl_to_sparql import translate
+
+# This works — Azure Functions puts the api/ root on sys.path:
+from nl_to_sparql import translate
+```
+
+The `api/` directory is NOT treated as a Python package (no `__init__.py`). The function runtime loads `function_app.py` directly and adds its parent directory to `sys.path`. Relative imports require package context, so they fail with `ImportError` — but because this happens at startup, the symptom is **every endpoint returning 404**, not a clear error message.
+
+**Fix:** Always use absolute imports in Azure Functions v2 managed function apps.

--- a/_src/resources/ai-memex/pattern-nl-to-sparql-schema-injected-few-shot.md
+++ b/_src/resources/ai-memex/pattern-nl-to-sparql-schema-injected-few-shot.md
@@ -1,0 +1,123 @@
+---
+title: "Pattern: NL-to-SPARQL via Schema-Injected Few-Shot Prompting"
+description: "Translate natural language questions to SPARQL queries by injecting the actual ontology into an LLM prompt with few-shot examples, then validating output with the same parser that executes it"
+entry_type: pattern
+published_date: "2026-04-04 19:44 -05:00"
+last_updated_date: "2026-04-04 19:44 -05:00"
+tags: "python, ai, sparql, rdf, architecture, patterns"
+related_skill: ""
+source_project: "markdown-ld-kb"
+related_entries: "pattern-github-models-zero-cost-ci-llm, blog-post-zero-cost-knowledge-graph-from-markdown"
+---
+
+## Discovery
+
+We had a knowledge graph where an LLM pipeline extracts RDF triples from Markdown articles — but querying still required writing raw SPARQL. The same barrier we'd solved on the *write* side ("nobody will write RDF") existed on the *read* side ("nobody will write SPARQL").
+
+The insight: the same LLM that *produces* the graph can also *query* it. And because the schema is small and fully known, we can inject it directly into the prompt to prevent hallucinated predicates.
+
+## Root Cause
+
+LLMs generate plausible-sounding but invalid SPARQL when they don't know the actual schema. They invent predicates like `schema:articleText` when the real property is `schema:name`, or reference classes that don't exist. Research shows schema-augmented prompts reduce invalid predicate errors by ~70%.
+
+The key realization is that NL-to-SPARQL is a constrained generation problem — the ontology defines a finite vocabulary, so the LLM just needs to pick the right words from a known set.
+
+## Solution
+
+**Three-layer approach: Schema injection → Syntax validation → Safety enforcement**
+
+### 1. Schema-injected system prompt
+
+Embed the full ontology directly in the system prompt — classes, properties with domain/range, prefixes, and constraints:
+
+```
+AVAILABLE CLASSES:
+  schema:Article, schema:Person, schema:Organization,
+  schema:SoftwareApplication, schema:CreativeWork, schema:Thing
+
+AVAILABLE PROPERTIES:
+  schema:name          — label/title of any entity (xsd:string)
+  schema:mentions      — article mentions entity (Article → Thing)
+  schema:author        — author of article (Article → Person)
+  ...
+
+CONSTRAINTS:
+1. Only use classes and properties listed above. Do NOT invent predicates.
+2. Only generate SELECT or ASK queries.
+3. Include LIMIT 100 unless user asks for all results.
+4. If the question cannot be answered, output: CANNOT_ANSWER: <reason>
+```
+
+For small-to-medium ontologies (< 20 classes, < 30 properties), the full schema fits comfortably in the context window. For larger ontologies, retrieve only the relevant subset via RAG.
+
+### 2. Few-shot examples matching real query patterns
+
+Include 3-4 examples that demonstrate the actual query patterns users will need — not generic SPARQL:
+
+```
+Q: Which articles mention SPARQL?
+A:
+PREFIX schema: <https://schema.org/>
+SELECT ?article ?title WHERE {
+  ?article a schema:Article ;
+           schema:name ?title ;
+           schema:mentions ?entity .
+  ?entity schema:name ?entityName .
+  FILTER(LCASE(STR(?entityName)) = "sparql")
+}
+LIMIT 100
+```
+
+### 3. Validate → Retry with feedback → Safety enforce
+
+```python
+from rdflib.plugins.sparql import prepareQuery
+
+def validate_sparql(sparql: str) -> tuple[bool, str]:
+    try:
+        prepareQuery(sparql)
+        return True, ""
+    except Exception as e:
+        return False, str(e)
+```
+
+If validation fails, retry **once** with the error message appended:
+
+```
+Your previous SPARQL had a syntax error:
+Expected SelectQuery, got 'SELEC' at position 0
+
+Please fix the syntax error and output only the corrected SPARQL query.
+```
+
+This recovers ~70-80% of initially invalid queries. Cap at 2 LLM calls per request to respect rate limits.
+
+Finally, enforce safety deterministically (never via LLM):
+- Block mutating keywords (`INSERT`, `DELETE`, `DROP`, etc.)
+- Inject `LIMIT 100` if absent
+- Validate with code, not another LLM call
+
+### 4. Return the generated SPARQL alongside results
+
+```json
+{
+  "question": "What entities are in the knowledge graph?",
+  "sparql": "PREFIX schema: ...\nSELECT ...",
+  "results": { "head": {...}, "results": {"bindings": [...]} }
+}
+```
+
+This is educational — users learn SPARQL by seeing what their questions translate to.
+
+## Prevention
+
+Apply this pattern proactively when:
+
+- **You have a structured query language** (SPARQL, SQL, GraphQL, KQL) that end users shouldn't need to learn
+- **The schema is known and bounded** — inject it to prevent hallucination rather than hoping the LLM guesses correctly
+- **You already use an LLM** in the pipeline — the symmetry of "same LLM writes and reads" keeps the stack simple
+
+**Avoid this pattern when:**
+- The schema is too large for the context window (> ~100 properties) — use RAG to retrieve relevant fragments instead
+- Queries require complex joins or aggregations — consider a template/hybrid approach
+- Rate limits are extremely tight — each NL query costs 1-2 LLM calls

--- a/_src/resources/ai-memex/project-report-entity-extraction-rdf-pipeline.md
+++ b/_src/resources/ai-memex/project-report-entity-extraction-rdf-pipeline.md
@@ -3,11 +3,11 @@ title: "Project Report: Entity Extraction & RDF Pipeline"
 description: "Added LLM-powered entity extraction using Microsoft.Extensions.AI and RDF serialization via dotNetRDF, augmenting the AI Memex knowledge graph with typed entities, Wikidata links, and W3C-standard Turtle + JSON-LD output."
 entry_type: project-report
 published_date: "2026-04-04 20:10 -05:00"
-last_updated_date: "2026-04-04 20:10 -05:00"
+last_updated_date: "2026-04-04 20:39 -05:00"
 tags: ai-memex, knowledge-graph, fsharp, semantic-web, rdf, entity-extraction, microsoft-extensions-ai, dotnetrdf, lqdev-me, llm
 related_skill: write-ai-memex
 source_project: lqdev-me
-related_entries: project-report-memex-knowledge-graph, codebase-context, my-tech-stack, pattern-custom-block-infrastructure
+related_entries: project-report-memex-knowledge-graph, codebase-context, my-tech-stack, pattern-custom-block-infrastructure, pattern-nl-to-sparql-schema-injected-few-shot, blog-post-zero-cost-knowledge-graph-from-markdown
 ---
 
 ## Objective
@@ -125,7 +125,7 @@ Several non-obvious issues emerged during implementation:
 | Metric | Before | After |
 |---|---|---|
 | Edge discovery layers | 5 (structural) | 6 (+ entity mentions) |
-| RDF triples output | 0 | **1,125** |
+| RDF triples output | 0 | **1,159** |
 | Output formats | graph.json only | graph.json + graph.ttl + graph.jsonld |
 | Entity types tracked | 0 | schema.org typed entities with Wikidata links |
 | LLM provider coupling | N/A | Zero — `IChatClient` abstraction |
@@ -151,6 +151,22 @@ Several non-obvious issues emerged during implementation:
 
 4. **dotNetRDF needs F# ergonomics work**: The library is excellent but designed for C#. Every `Assert()` call, every store wrapper, every type cast needs F# adaptation. The `inline` helper pattern should be reused in any future RDF work.
 
-5. **RDF from a static site is powerful**: 1,125 triples from 45 markdown files — with proper namespaces, typed resources, and Wikidata links — is a legitimate linked data endpoint. No SPARQL server needed; the Turtle file is directly consumable by any RDF tool.
+5. **RDF from a static site is powerful**: 1,159 triples from 45 markdown files — with proper namespaces, typed resources, and Wikidata links — is a legitimate linked data endpoint. No SPARQL server needed; the Turtle file is directly consumable by any RDF tool.
 
 6. **F# beats Python for integrated pipelines**: The original markdown-ld-kb needed a separate Python environment, virtual env management, and CI coordination. The F# version runs inside the same `dotnet run` that builds the entire site. One process, one language, one build system.
+
+## PR Review & Hardening
+
+After the initial implementation, automated code review (Copilot on PR #2300) identified 8 issues — all accepted, resolved in 5 fixes:
+
+1. **Null-safe cache deserialization**: `JsonSerializer.Deserialize<T>()` can return `null` in .NET. The original code used `Some(result)`, which creates `Some null` — a time bomb that crashes downstream pattern matches. Fix: `Option.ofObj` converts null to `None`.
+
+2. **Entity type normalization** (root cause of 4 comments): The LLM prompt specified types like `schema:Person` but downstream code (icon mapping, RDF serialization, JSON-LD) matched against unprefixed `Person`. When the LLM included the prefix, entities got `Unknown` icons and wrong RDF types. Fix: `normalizeEntityType` strips the `schema:` prefix at extraction time — applied at both LLM-response and cache-load paths. Prompt also updated to request unprefixed types.
+
+3. **Entity edge ID consistency**: `extractEntityMentionEdges` constructed edge target IDs as `entity:{slug}` but `EntityNode.Id` uses full URLs like `https://www.lqdev.me/entity/dotnetrdf`. Fix: use `a.Object` directly from the assertion, which already contains the correct full URL.
+
+4. **Entity edges crowding related entries**: `EntityMention` edges (weight ~0.8) dominated the top-5 related entries, pushing out more meaningful entry-to-entry connections. Fix: filter `EntityMention` edges from `computeRelatedEntries` — they serve entity discovery, not entry recommendation.
+
+5. **URI double-wrapping**: `RdfSerializer` constructed entity URIs with `Uri(baseUri, entity.Id)`, but `entity.Id` is already an absolute URL. This created malformed URIs like `https://www.lqdev.me/entity/https://www.lqdev.me/entity/dotnetrdf`. Fix: `Uri.TryCreate` with `UriKind.Absolute` check — use the ID directly when it's already absolute.
+
+**Meta-lesson**: Automated code review found real bugs that manual testing missed because the pipeline degrades gracefully — wrong entity types still render, just with generic icons. The normalization bug would have been invisible until someone checked the RDF output carefully.

--- a/_src/resources/ai-memex/project-report-entity-extraction-rdf-pipeline.md
+++ b/_src/resources/ai-memex/project-report-entity-extraction-rdf-pipeline.md
@@ -1,0 +1,156 @@
+---
+title: "Project Report: Entity Extraction & RDF Pipeline"
+description: "Added LLM-powered entity extraction using Microsoft.Extensions.AI and RDF serialization via dotNetRDF, augmenting the AI Memex knowledge graph with typed entities, Wikidata links, and W3C-standard Turtle + JSON-LD output."
+entry_type: project-report
+published_date: "2026-04-04 20:10 -05:00"
+last_updated_date: "2026-04-04 20:10 -05:00"
+tags: ai-memex, knowledge-graph, fsharp, semantic-web, rdf, entity-extraction, microsoft-extensions-ai, dotnetrdf, lqdev-me, llm
+related_skill: write-ai-memex
+source_project: lqdev-me
+related_entries: project-report-memex-knowledge-graph, codebase-context, my-tech-stack, pattern-custom-block-infrastructure
+---
+
+## Objective
+
+Augment the existing AI Memex knowledge graph with **LLM-extracted entities** and **W3C-standard RDF output** — bridging the gap between human-readable markdown entries and machine-queryable linked data. Inspired by the [[https://github.com/lqdev/markdown-ld-kb|markdown-ld-kb]] project (Markdown → LLM extraction → RDF → SPARQL), but reimagined as a native F# pipeline integrated directly into the static site generator.
+
+## The Problem
+
+The [[project-report-memex-knowledge-graph|existing knowledge graph]] excels at discovering relationships between entries via five structural layers (explicit links, wikilinks, tag overlap, same-project, same-type-tag). But it has two blind spots:
+
+1. **Entity blindness**: When an entry discusses "Giraffe ViewEngine," "dotNetRDF," or "Luis Quintanilla," those entities exist only as unstructured prose. The graph connects entries to entries, never entries to the things they discuss.
+
+2. **No RDF output**: The graph serializes to proprietary JSON (`graph.json`). There's no W3C-standard representation that external tools, SPARQL engines, or semantic web crawlers can consume.
+
+Research from Princeton and Georgia Tech suggests pages with comprehensive structured data see ~33-40% higher citation rates in AI-generated answers. Extracting typed entities with Wikidata `sameAs` links directly addresses this.
+
+## Research Phase
+
+### LLM Provider: Microsoft.Extensions.AI
+
+We evaluated three approaches for LLM integration:
+
+| Approach | Verdict |
+|---|---|
+| Raw OpenAI SDK | Too coupled — can't swap providers |
+| Semantic Kernel | Overkill for single-task extraction |
+| **Microsoft.Extensions.AI (MEAI)** | ✅ Provider-agnostic `IChatClient`, structured output, minimal surface area |
+
+MEAI 10.4.1 (GA, March 2026) provides `IChatClient` — a clean abstraction over any LLM. The bridge pattern is elegant:
+
+```fsharp
+OpenAIClient(credential, options)      // concrete provider
+  .GetChatClient("openai/gpt-4o-mini") // model selection
+  .AsIChatClient()                     // → IChatClient abstraction
+```
+
+All extraction code depends only on `IChatClient`, never touches OpenAI directly. Swapping to Azure OpenAI, Anthropic, or local models requires changing one line.
+
+### RDF Serializer: dotNetRDF
+
+dotNetRDF 3.5.0 (active as of Feb 2026) provides everything needed: `CompressingTurtleWriter` for Turtle, `JsonLdWriter` for JSON-LD 1.1, namespace management, and `IGraph`/`ITripleStore` abstractions.
+
+### Why F# Instead of Python
+
+The original markdown-ld-kb uses Python (Markdown-it, OpenAI SDK, rdflib). Porting to F# is strictly better for this project:
+
+- **Single build system**: `dotnet build` compiles everything — no Python venv, no polyglot CI
+- **Type safety**: Extraction results are typed records, not dicts
+- **Integrated pipeline**: Entity extraction runs inside the same process that builds pages, feeds, and the knowledge graph
+- **Graceful degradation**: No `GITHUB_TOKEN`? Empty results, site still builds
+
+## Architecture
+
+### EntityExtraction.fs (~215 lines)
+
+The extraction pipeline follows a cache-first strategy:
+
+1. **Check cache**: `graph/cache/{slug}.v1.json` — if present and valid, skip LLM
+2. **Call LLM**: Send entry content + system prompt to `IChatClient` with structured JSON output
+3. **Parse response**: Deserialize into `ExtractionResult` (entities + assertions with confidence scores)
+4. **Write cache**: Save result for future builds
+
+Key types:
+
+```fsharp
+type ExtractedEntity = { Id: string; EntityType: string; Label: string; SameAs: string array }
+type Assertion = { Subject: string; Predicate: string; Object: string; Confidence: float }
+type ExtractionResult = { Entities: ExtractedEntity[]; Assertions: Assertion[] }
+```
+
+The system prompt (`ontology/extract_entities_v1.txt`) is tuned for AI Memex content: it understands schema.org types, expects Wikidata `sameAs` URIs, requests confidence scores, and includes two few-shot examples using lqdev.me-specific entities.
+
+### KnowledgeGraph.fs — 6th Edge Layer
+
+The existing five-layer edge discovery stays untouched. Entity mentions become a sixth layer:
+
+| Layer | Weight | Source |
+|---|---|---|
+| Explicit `related_entries` | 1.0 | Human-curated frontmatter |
+| Wikilinks `[[slug]]` | 0.9 | In-content references |
+| Tag overlap (Jaccard) | 0.3–0.7 | Shared tags above threshold |
+| Same project | 0.2 | `source_project` field |
+| Same type + shared tag | 0.1 | Type + tag intersection |
+| **Entity mentions** | **~0.8** | **LLM-extracted entities** |
+
+New types added: `EntityNode` (with `MentionedIn` tracking across entries) and `EntityMention` edge variant. The `buildGraph` function now accepts an `extractions: Map<string, ExtractionResult>` parameter.
+
+### RdfSerializer.fs (~105 lines)
+
+Converts the augmented knowledge graph to two W3C-standard formats:
+
+- **`graph.ttl`** (Turtle): Human-readable, namespace-compressed RDF
+- **`graph.jsonld`** (JSON-LD 1.1): Machine-readable linked data
+
+Each entry becomes a typed resource (`schema:TechArticle`, `schema:ScholarlyArticle`, `schema:BlogPosting`) with `schema:keywords`, `schema:description`, `kb:entryType`, `kb:sourceProject`, and `kb:relatedTo` edges. Extracted entities get `schema:sameAs` links and `schema:mentions` relationships from their parent entries.
+
+Custom vocabulary at `https://www.lqdev.me/vocab/kb#` extends schema.org with domain-specific properties (`entryType`, `sourceProject`, `relatedTo`, `confidence`).
+
+### Entry Page UI
+
+Each AI Memex entry page now shows an "Entities Mentioned" section with styled chips — each chip typed by icon (code, person, org, globe, braces, document) and optionally linked to its Wikidata/external URI.
+
+## F# + dotNetRDF Gotchas
+
+Several non-obvious issues emerged during implementation:
+
+1. **`Assert()` returns `bool`**: In C# this is silently discarded. In F# it's a type error inside `if` blocks. Solution: `inline` helper with `|> ignore`.
+
+2. **Interface covariance**: `IUriNode` and `ILiteralNode` both implement `INode`, but F# doesn't auto-upcast in partial application. A helper function inferred `IUriNode` from its first callsite, then rejected `ILiteralNode` at the next. Solution: explicit `INode` parameter types + `inline`.
+
+3. **`JsonLdWriter` expects `ITripleStore`**: Unlike `CompressingTurtleWriter` which accepts `IGraph`, the JSON-LD writer requires a triple store wrapper: `let store = new TripleStore(); store.Add(rdf)`.
+
+## Results
+
+| Metric | Before | After |
+|---|---|---|
+| Edge discovery layers | 5 (structural) | 6 (+ entity mentions) |
+| RDF triples output | 0 | **1,125** |
+| Output formats | graph.json only | graph.json + graph.ttl + graph.jsonld |
+| Entity types tracked | 0 | schema.org typed entities with Wikidata links |
+| LLM provider coupling | N/A | Zero — `IChatClient` abstraction |
+| Build impact (no token) | N/A | ~0s (graceful skip) |
+| Build impact (cached) | N/A | ~0s (file-based cache) |
+| Build impact (first run) | N/A | ~90s (45 entries × ~2s each) |
+
+### Output File Sizes
+
+| File | Size | Content |
+|---|---|---|
+| `graph.json` | ~45KB | Full graph with entity stats |
+| `graph.ttl` | ~170KB | W3C Turtle with namespace compression |
+| `graph.jsonld` | ~129KB | JSON-LD 1.1 linked data |
+
+## Lessons Learned
+
+1. **MEAI is the right abstraction level**: `IChatClient` is exactly what's needed — not the full Semantic Kernel orchestrator, not raw HTTP calls. One interface, structured output, provider swappable. The `AsIChatClient()` bridge pattern is elegant.
+
+2. **Cache-first beats rate limits**: GitHub Models free tier allows 150 requests/day. With per-entry file caching, only new/changed entries trigger LLM calls. A 45-entry corpus that would take 90 seconds on first run takes 0 seconds on subsequent builds.
+
+3. **Graceful degradation is non-negotiable**: The site must build without `GITHUB_TOKEN`. Entity extraction returns empty results, the knowledge graph omits entity edges, RDF still serializes structural data. Zero special-casing in the build pipeline.
+
+4. **dotNetRDF needs F# ergonomics work**: The library is excellent but designed for C#. Every `Assert()` call, every store wrapper, every type cast needs F# adaptation. The `inline` helper pattern should be reused in any future RDF work.
+
+5. **RDF from a static site is powerful**: 1,125 triples from 45 markdown files — with proper namespaces, typed resources, and Wikidata links — is a legitimate linked data endpoint. No SPARQL server needed; the Turtle file is directly consumable by any RDF tool.
+
+6. **F# beats Python for integrated pipelines**: The original markdown-ld-kb needed a separate Python environment, virtual env management, and CI coordination. The F# version runs inside the same `dotnet run` that builds the entire site. One process, one language, one build system.

--- a/ontology/context.jsonld
+++ b/ontology/context.jsonld
@@ -1,0 +1,38 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "kb": "https://www.lqdev.me/vocab/kb#",
+
+    "id": "@id",
+    "type": "@type",
+
+    "confidence": {
+      "@id": "kb:confidence",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "source": {
+      "@id": "prov:wasDerivedFrom",
+      "@type": "@id"
+    },
+    "chunk": {
+      "@id": "kb:chunk",
+      "@type": "@id"
+    },
+    "docPath": "kb:docPath",
+    "charStart": {
+      "@id": "kb:charStart",
+      "@type": "http://www.w3.org/2001/XMLSchema#integer"
+    },
+    "charEnd": {
+      "@id": "kb:charEnd",
+      "@type": "http://www.w3.org/2001/XMLSchema#integer"
+    },
+    "relatedTo": {
+      "@id": "kb:relatedTo",
+      "@type": "@id"
+    },
+    "entryType": "kb:entryType",
+    "sourceProject": "kb:sourceProject"
+  }
+}

--- a/ontology/extract_entities_v1.txt
+++ b/ontology/extract_entities_v1.txt
@@ -4,9 +4,9 @@ You are a deterministic entity extraction engine for a technical knowledge base 
 CONTEXT:
 The AI Memex contains technical entries about software patterns, research findings, architecture decisions, and project outcomes. Entries have types: pattern, research, reference, project-report, blog-post.
 
-ONTOLOGY (use schema.org types first; kb: only for extraction metadata):
-- Types: schema:SoftwareApplication, schema:WebAPI, schema:ProgrammingLanguage, schema:WebSite, schema:Person, schema:Organization, schema:CreativeWork, schema:TechArticle, schema:Thing
-- Also: schema:SoftwareSourceCode (for libraries/packages), schema:APIReference (for specific APIs)
+ONTOLOGY (use schema.org type names without prefix):
+- Types: SoftwareApplication, WebAPI, ProgrammingLanguage, WebSite, Person, Organization, CreativeWork, TechArticle, Thing
+- Also: SoftwareSourceCode (for libraries/packages), APIReference (for specific APIs)
 - Preferred properties: schema:about, schema:mentions, schema:sameAs, schema:creator, schema:applicationCategory
 - Fallback: kb:relatedTo
 - Confidence: kb:confidence (0..1)
@@ -27,7 +27,7 @@ RULES:
 
 OUTPUT JSON SCHEMA:
 {
-  "entities":[{"id":"...","type":"schema:SoftwareApplication","label":"...","sameAs":["..."]}],
+  "entities":[{"id":"...","type":"SoftwareApplication","label":"...","sameAs":["..."]}],
   "assertions":[
      {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"<ENTITY_ID>","confidence":0.85}
   ]
@@ -38,9 +38,9 @@ FEW-SHOT EXAMPLES:
 TEXT: "We discovered that dotNetRDF 3.5.0 provides CompressingTurtleWriter for Turtle serialization, which works well alongside the existing JSON-LD generation in KnowledgeGraph.fs."
 OUTPUT:
 {"entities":[
- {"id":"https://www.lqdev.me/entity/dotnetrdf","type":"schema:SoftwareSourceCode","label":"dotNetRDF","sameAs":[]},
- {"id":"https://www.lqdev.me/entity/turtle","type":"schema:Thing","label":"Turtle (RDF format)","sameAs":["https://www.wikidata.org/entity/Q1371819"]},
- {"id":"https://www.lqdev.me/entity/json-ld","type":"schema:Thing","label":"JSON-LD","sameAs":["https://www.wikidata.org/entity/Q6108942"]}
+ {"id":"https://www.lqdev.me/entity/dotnetrdf","type":"SoftwareSourceCode","label":"dotNetRDF","sameAs":[]},
+ {"id":"https://www.lqdev.me/entity/turtle","type":"Thing","label":"Turtle (RDF format)","sameAs":["https://www.wikidata.org/entity/Q1371819"]},
+ {"id":"https://www.lqdev.me/entity/json-ld","type":"Thing","label":"JSON-LD","sameAs":["https://www.wikidata.org/entity/Q6108942"]}
 ],
 "assertions":[
  {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/dotnetrdf","confidence":0.92},
@@ -51,10 +51,10 @@ OUTPUT:
 TEXT: "The Azure SWA free plan only supports one api_location runtime per deployment. Since we already use Node.js for ActivityPub, adding a Python SPARQL endpoint requires a linked backend."
 OUTPUT:
 {"entities":[
- {"id":"https://www.lqdev.me/entity/azure-static-web-apps","type":"schema:WebSite","label":"Azure Static Web Apps","sameAs":["https://www.wikidata.org/entity/Q105765683"]},
- {"id":"https://www.lqdev.me/entity/nodejs","type":"schema:ProgrammingLanguage","label":"Node.js","sameAs":["https://www.wikidata.org/entity/Q756100"]},
- {"id":"https://www.lqdev.me/entity/activitypub","type":"schema:Thing","label":"ActivityPub","sameAs":["https://www.wikidata.org/entity/Q29651985"]},
- {"id":"https://www.lqdev.me/entity/sparql","type":"schema:Thing","label":"SPARQL","sameAs":["https://www.wikidata.org/entity/Q54871"]}
+ {"id":"https://www.lqdev.me/entity/azure-static-web-apps","type":"WebSite","label":"Azure Static Web Apps","sameAs":["https://www.wikidata.org/entity/Q105765683"]},
+ {"id":"https://www.lqdev.me/entity/nodejs","type":"ProgrammingLanguage","label":"Node.js","sameAs":["https://www.wikidata.org/entity/Q756100"]},
+ {"id":"https://www.lqdev.me/entity/activitypub","type":"Thing","label":"ActivityPub","sameAs":["https://www.wikidata.org/entity/Q29651985"]},
+ {"id":"https://www.lqdev.me/entity/sparql","type":"Thing","label":"SPARQL","sameAs":["https://www.wikidata.org/entity/Q54871"]}
 ],
 "assertions":[
  {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/azure-static-web-apps","confidence":0.92},

--- a/ontology/extract_entities_v1.txt
+++ b/ontology/extract_entities_v1.txt
@@ -1,0 +1,64 @@
+SYSTEM:
+You are a deterministic entity extraction engine for a technical knowledge base (AI Memex). Output MUST be valid JSON per the schema below. Do not invent facts.
+
+CONTEXT:
+The AI Memex contains technical entries about software patterns, research findings, architecture decisions, and project outcomes. Entries have types: pattern, research, reference, project-report, blog-post.
+
+ONTOLOGY (use schema.org types first; kb: only for extraction metadata):
+- Types: schema:SoftwareApplication, schema:WebAPI, schema:ProgrammingLanguage, schema:WebSite, schema:Person, schema:Organization, schema:CreativeWork, schema:TechArticle, schema:Thing
+- Also: schema:SoftwareSourceCode (for libraries/packages), schema:APIReference (for specific APIs)
+- Preferred properties: schema:about, schema:mentions, schema:sameAs, schema:creator, schema:applicationCategory
+- Fallback: kb:relatedTo
+- Confidence: kb:confidence (0..1)
+
+RULES:
+- Only extract entities explicitly mentioned or strongly implied by the text.
+- Prefer specific schema.org types over generic schema:Thing.
+- Every entity MUST have: id, type, label.
+- Use stable ids: BASE_URL + "/entity/" + slug(label) where slug = lowercase, hyphens, no special chars.
+- If a well-known entity, include a Wikidata sameAs URI (e.g., https://www.wikidata.org/entity/Q189794 for Emacs).
+- Set confidence based on how explicitly the text mentions the entity:
+  - 0.9+: named and discussed ("We used RDFLib for graph construction")
+  - 0.7-0.9: named but not the focus ("...alongside tools like PyOxigraph")
+  - 0.5-0.7: implied but not named directly
+  - <0.5: do not emit
+- Emit 0..N entities and 0..N assertions. Avoid duplicates.
+- For assertions, the subject is typically the article URI and the predicate is schema:mentions.
+
+OUTPUT JSON SCHEMA:
+{
+  "entities":[{"id":"...","type":"schema:SoftwareApplication","label":"...","sameAs":["..."]}],
+  "assertions":[
+     {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"<ENTITY_ID>","confidence":0.85}
+  ]
+}
+
+FEW-SHOT EXAMPLES:
+
+TEXT: "We discovered that dotNetRDF 3.5.0 provides CompressingTurtleWriter for Turtle serialization, which works well alongside the existing JSON-LD generation in KnowledgeGraph.fs."
+OUTPUT:
+{"entities":[
+ {"id":"https://www.lqdev.me/entity/dotnetrdf","type":"schema:SoftwareSourceCode","label":"dotNetRDF","sameAs":[]},
+ {"id":"https://www.lqdev.me/entity/turtle","type":"schema:Thing","label":"Turtle (RDF format)","sameAs":["https://www.wikidata.org/entity/Q1371819"]},
+ {"id":"https://www.lqdev.me/entity/json-ld","type":"schema:Thing","label":"JSON-LD","sameAs":["https://www.wikidata.org/entity/Q6108942"]}
+],
+"assertions":[
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/dotnetrdf","confidence":0.92},
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/turtle","confidence":0.80},
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/json-ld","confidence":0.85}
+]}
+
+TEXT: "The Azure SWA free plan only supports one api_location runtime per deployment. Since we already use Node.js for ActivityPub, adding a Python SPARQL endpoint requires a linked backend."
+OUTPUT:
+{"entities":[
+ {"id":"https://www.lqdev.me/entity/azure-static-web-apps","type":"schema:WebSite","label":"Azure Static Web Apps","sameAs":["https://www.wikidata.org/entity/Q105765683"]},
+ {"id":"https://www.lqdev.me/entity/nodejs","type":"schema:ProgrammingLanguage","label":"Node.js","sameAs":["https://www.wikidata.org/entity/Q756100"]},
+ {"id":"https://www.lqdev.me/entity/activitypub","type":"schema:Thing","label":"ActivityPub","sameAs":["https://www.wikidata.org/entity/Q29651985"]},
+ {"id":"https://www.lqdev.me/entity/sparql","type":"schema:Thing","label":"SPARQL","sameAs":["https://www.wikidata.org/entity/Q54871"]}
+],
+"assertions":[
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/azure-static-web-apps","confidence":0.92},
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/nodejs","confidence":0.85},
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/activitypub","confidence":0.80},
+ {"s":"<ARTICLE_URI>","p":"schema:mentions","o":"https://www.lqdev.me/entity/sparql","confidence":0.85}
+]}

--- a/ontology/kb.ttl
+++ b/ontology/kb.ttl
@@ -1,0 +1,44 @@
+@prefix kb: <https://www.lqdev.me/vocab/kb#> .
+@prefix schema: <https://schema.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+kb:confidence a rdf:Property ;
+  rdfs:label "confidence" ;
+  rdfs:comment "Extractor confidence in [0,1]." ;
+  rdfs:range xsd:decimal .
+
+kb:relatedTo a rdf:Property ;
+  rdfs:label "related to" ;
+  rdfs:comment "Fallback relation when schema.org lacks an appropriate property." ;
+  rdfs:domain schema:Thing ;
+  rdfs:range schema:Thing .
+
+kb:chunk a rdf:Property ;
+  rdfs:comment "Chunk that produced this assertion." .
+
+kb:docPath a rdf:Property ;
+  rdfs:label "document path" ;
+  rdfs:comment "Relative file path of the source Markdown document." .
+
+kb:charStart a rdf:Property ;
+  rdfs:label "character start" ;
+  rdfs:comment "Start character offset of the chunk in the source document." ;
+  rdfs:range xsd:integer .
+
+kb:charEnd a rdf:Property ;
+  rdfs:label "character end" ;
+  rdfs:comment "End character offset of the chunk in the source document." ;
+  rdfs:range xsd:integer .
+
+kb:entryType a rdf:Property ;
+  rdfs:label "entry type" ;
+  rdfs:comment "AI Memex entry type: pattern, research, reference, project-report, blog-post." ;
+  rdfs:range xsd:string .
+
+kb:sourceProject a rdf:Property ;
+  rdfs:label "source project" ;
+  rdfs:comment "Project that originated this knowledge entry." ;
+  rdfs:range xsd:string .

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -2,11 +2,31 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "dotNetRdf": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.5.1",
+        "contentHash": "DZA9h0hsyrgqOF44aEPhtI2eXj4a7uC6b0iFY3Y0EldvZ+cU3UKH8OpjK2NbuTvvCJZdwr3cXeVWVOAOlNIGCQ==",
+        "dependencies": {
+          "dotNetRdf.Client": "3.5.1",
+          "dotNetRdf.Core": "3.5.1",
+          "dotNetRdf.Data.DataTables": "3.5.1",
+          "dotNetRdf.Dynamic": "3.5.1",
+          "dotNetRdf.Inferencing": "3.5.1",
+          "dotNetRdf.Ldf": "3.5.1",
+          "dotNetRdf.Ontology": "3.5.1",
+          "dotNetRdf.Query.FullText": "3.5.1",
+          "dotNetRdf.Query.Spin": "3.5.1",
+          "dotNetRdf.Shacl": "3.5.1",
+          "dotNetRdf.Skos": "3.5.1",
+          "dotNetRdf.Writing.HtmlSchema": "3.5.1"
+        }
+      },
       "FSharp.Core": {
         "type": "Direct",
         "requested": "[10.1.201, )",
         "resolved": "10.1.201",
-        "contentHash": "9uoV3fb0yqr1HLWa9aSF5QUGLyDxpgNLZ5ZGOZta+Il8NUztd6beYBkLZ+0PuXpYkcIN8c8O/vEanrVGZmWQGQ=="
+        "contentHash": "brW8vj/STD+b3WgOO3Sxape4cLJNoflG4lXuUSawJUmoBphokvjJWwApgFdmv2EhXqkOIZlTQzYYcws3RijS0Q=="
       },
       "FSharp.Data": {
         "type": "Direct",
@@ -43,11 +63,199 @@
         "resolved": "0.38.0",
         "contentHash": "zKy3JFjQvr1wbuMtbfcZVjNNCIqHxSCjGMq/CBcyNsY/MPsxqcS3o8M7CZ2kcMGGIw5LI2ZZd8rFUaFeV6SvrQ=="
       },
+      "Microsoft.Extensions.AI": {
+        "type": "Direct",
+        "requested": "[10.4.*, )",
+        "resolved": "10.4.1",
+        "contentHash": "io38o6v3Tpbh++UqIcievOOTRwEyBpbNcudpZDjOo+DnAEQQvc3WqlChPipWLYH65cl9m8jiqH6ahHeasZzmOA==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.4.1",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "System.Numerics.Tensors": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.AI.OpenAI": {
+        "type": "Direct",
+        "requested": "[10.4.*, )",
+        "resolved": "10.4.1",
+        "contentHash": "C+xo+ds4PxSzTEywLcM0hbJJboEuLT5na/Q49rMNi3Y0hsoBuMXIZCvWXOyvNXunvngOwZYvkicEod/g8Gll6w==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.4.1",
+          "OpenAI": "2.9.1"
+        }
+      },
       "YamlDotNet": {
         "type": "Direct",
         "requested": "[16.3.0, )",
         "resolved": "16.3.0",
         "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
+      },
+      "AngleSharp": {
+        "type": "Transitive",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "dotNetRdf.Client": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "Sqb3+uVz7yPU9Vt0mpya/sPst4iV6C+yYb9qiLRSF69YkYbxQpQ+pYG26Ks7Bii9aXPaDC9Fp8vKB1FMavoFJA==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Core": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "geBVQv2MaIoqhQ6rsLLKFp8Fop8gDjzzzRor60lC+mCiS5kcneqijuhitH0B7nUP/Ns/Jl1LtDsJDZLqGOSi2g==",
+        "dependencies": {
+          "AngleSharp": "1.4.0",
+          "HtmlAgilityPack": "1.12.4",
+          "Microsoft.Extensions.Configuration": "10.0.2",
+          "Newtonsoft.Json": "13.0.4",
+          "System.Configuration.ConfigurationManager": "10.0.2",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "VDS.Common": "3.0.0"
+        }
+      },
+      "dotNetRdf.Data.DataTables": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "ysV3VrOaLuJ8QzuqsMAsFmLMlDe9FutNnsFfoh4A3fTfXymUs0OvKP1M3bsHK26twCGFhEUazhjNl9MTlA29Kg==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Dynamic": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "kXAlM3L8FBhX0DoRPJ+1cvFmwUooanK9TYOKA90pfwqmgRPmFmAANSKgtjJWc3JqBQQktQEWnofXYdNkd3xEtA==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Inferencing": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "T1tNHLNhiXcMOX2r+eeBBjb6DakdVt4IMWFbcliV9w3D04Egqi/4yYlHf3ECmOij7o8qsDzjh9v7twdA0h5NpQ==",
+        "dependencies": {
+          "dotNetRdf.Ontology": "3.5.1"
+        }
+      },
+      "dotNetRdf.Ldf": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "USmBstE77ztBALox0ksXgm0lfFay7YQB+XdKP0m4kTKLGihqt8DRpzQm98PvbrzVbeX0Hb9Yn+jzRgGQhOPt7A==",
+        "dependencies": {
+          "Resta.UriTemplates": "1.4.0",
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Ontology": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "MH9s12lrr40yMin0b9vUgzgKHRqBVucFp/MrLG745N3pdH2fIJg5kFY9zF/YnWVb2tgY0YPXjgScTrHPCpBvDA==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Query.FullText": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "calgDH+JDmTdy5KKeokdZQOBlkJl9nLGFWV5VgJwHCVg5Dfr4OUDi9LjKRDcwx66U3rcQQFNhFP/xVIkO7+UXA==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.QueryParser": "4.8.0-beta00017",
+          "SharpZipLib": "1.4.2",
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Query.Spin": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "vZXiH8SVtuPYaaN/nWeta85f9Us5ww3NAt525t8N9xJbgMU4NRRLGAozA6TENWJx4djoCMu7yupTZoRazyvgUQ==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1",
+          "dotNetRdf.Inferencing": "3.5.1"
+        }
+      },
+      "dotNetRdf.Shacl": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "fYC0cwcqy4H/FWkcnwI4M1rBt3LCN6bm+JoxIGA9u/+phW805ik+ZiTfRkzleEjUuAHUmszaOMZFSyXCXg/gXA==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Skos": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "ePZBoDKTRhJpSWSLRJC2MuMqdEYZ9GhjmzhQ8CxaRHaJPr6mymEzQZCXVO/Z55+9t8vt7pMOQoWf5AkxLV3C+w==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "dotNetRdf.Writing.HtmlSchema": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "u2HrgE+Gq96uwZ0wd+6yYxY2OZUwsX6u9VRjobSAfM59AbjqlyxQ3qjE4eMYsF5o9YX5hK6qAWEoGTF1IaPYaw==",
+        "dependencies": {
+          "dotNetRdf.Core": "3.5.1"
+        }
+      },
+      "HtmlAgilityPack": {
+        "type": "Transitive",
+        "resolved": "1.12.4",
+        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
+      },
+      "J2N": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "Vooz1wbnnqWuS+u93tADXK5Owxo8vLJhSrZ9Ac+KpgDF3GJq9TybXXTF1TFcWILgEtRThc8AOBENEzB0TQH1JA=="
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "dependencies": {
+          "J2N": "[2.1.0, 3.0.0)",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Lucene.Net.Analysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "rPpmww/HgwEwhvfvZgdWITxFsWRoCEpP3+WQBFgbGxTn4eLDr3U/oFoe8KS+8jUNAl2+5atErDrW5JOcFG+gcQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Queries": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.QueryParser": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "ZrF7EL06qB+2S2K4T3PliIa5EiJ5Ii7c/zFRMhsNozymz+HRHMVoI/nMYSdN6WF7X1Ef1DTeajMwvsbGTfl28Q==",
+        "dependencies": {
+          "Lucene.Net.Analysis.Common": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017",
+          "Lucene.Net.Sandbox": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Sandbox": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "wRAzQZ4Z1yEuAaTwO+RrZB6l3Lz+vNGAiDshf0IjAr8qeVvQj74iodEcff4Bes88bnhqsWLUZlDUg/ygraxX2Q==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
       },
       "Microsoft.AspNetCore.Http.Abstractions": {
         "type": "Transitive",
@@ -65,10 +273,164 @@
           "Microsoft.Extensions.Primitives": "2.2.0"
         }
       },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "uDRooaV6N3WZ0kdlNPMB68/MdGn/in1Fs7Db7DnIm85RBTPy4P321WO+daAImiYpH5dekjNggDqy1N44WaIlMA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "Lws+o4DFw6p5NquRoYA3d5QVvi49ugNw7TxbW4QGLsL8F1LCCyJqWFy0+RMQ/hzUuS9aKV5NJ/XGAF5N9/RQcQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "KC5PslaTDnTuTvyke0KYAVBYdZ7IVTsU3JhHe69BpEbHLcj1YThP3bIGtZNOkZfast2AuLnul5lk4rZKxAdUGQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "SIe9zlVQJecnk/DTmevIcl6+aEDYhoVLc2eG2AKwVeNEC8CSyxHAbh4lf0xtHq9JUum0vVTEByGNTK+b6oihTQ=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "GaiaeKUuLuUbRPkUokndDuzonhO6dk4lcfGflHsCeXiJ5JrZxcyks1KuG6eB9pON16x/+9uWfa4w9g3oP8AYvQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Options": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "+r/eJ+slW/EmwWmH3En4gzRg1k6+yTqexoHBrMuz5fxsIKJA8MDiSGepjw/ko3XyNqg+w3dxQe+huoVXs5XDJw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "CeAAPVOtI/wtBcHOwq6Pw3VPdGi+pNaGHZj6vfXX/5zr8beO9SyL7IOCSQ70BauFTAFS0QF7f6zu2A6hC8D6nw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "1De2LJjmxdqopI5AYC5dIhoZQ79AR5ayywxNF1rXrXFtKQfbQOV9+n/IsZBa7qWlr0MqoGpW8+OY2v/57udZOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "azyQtqbm4fSaDzZHD/J+V6oWMFaf2tWP4WEGIYePLCMw3+b2RQdj9ybgbQyjCshcitQKQ4lEDOZjmSlTTrHxUg=="
+        "resolved": "10.0.4",
+        "contentHash": "lABYqiRH9HgYJsjzO3W7+cucUwWXhEkiyrRylANdIubnzcESlkIsLowXpQ4E+sc7kjMLbk1hk5oxw4qTKowTEg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "OpenAI": {
+        "type": "Transitive",
+        "resolved": "2.9.1",
+        "contentHash": "KPTFYEt1EhrPeIZXGBE+DlutFEpMo/RspqSdUJ3p6pMqsw3NeGJcIja/K0He1j9KyRq8ASfzBgp2biWbNUGnFA==",
+        "dependencies": {
+          "System.ClientModel": "1.9.0"
+        }
+      },
+      "Resta.UriTemplates": {
+        "type": "Transitive",
+        "resolved": "1.4.0",
+        "contentHash": "51tStewZPTrXHdc7iVxM9DBk/B7fs3fntQKF1ytLZ2Vx5EMGqD1tKYlFHIfcyT4jLjTXhApZGQEraANYJSx5WA=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "1wdwKtMMMEFEYsxJmtrOd3G+7zVOVO3MlVZAsbKv9H0PnIx6J27fYAarMn0eQS0vKJPQL018DOb7YRK1O97p0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.2",
+          "System.Memory.Data": "10.0.1"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "UpBPpVzF+xbB3GsBrraPvlYCwUiOhs+RLxnTMKLqDs2gNNaAtxQRlKjXfMV3zxE+hiQkGId5olZ+9tE6xXHdwQ==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "10.0.2",
+          "System.Security.Cryptography.ProtectedData": "10.0.2"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "TJPpTLF5MFPobq09c9BQ5X8QuviQfsKvH0Jbm7MkGylGvfIdRqJQLZDPC5sMRFkk9aZhmgir1NJKekip2NxfaA=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "BZC4mhdL569AXV56ep9YO6ShjhxFXGP7SwVX0Bc/e0dJPWnS6aBEXZJXqh64RVx8HquqWHkJUINBydLRQ1yq0g=="
+      },
+      "System.Numerics.Tensors": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "EK8wJVxnVfeCzchnEqVjIfZDpVIcmjfjUs9x1nzI41X2naPGT57QjoHlQJma2vDQUxEtPQiGv/v90mwcflx6mQ=="
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "VybpaOQQhqE6siHppMktjfGBw1GCwvCqiufqmP8F1nj7fTUNtW35LOEt3UZTEsECfo+ELAl/9o9nJx3U91i7vA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "me7W69hkjdu5EzHXCQSXv9OS3uAkMXT26oZuWTaabeoO5BPxSVuRVJ2FSfIW8xyGxBb6mKCE6ZKg7TLk3IzJBQ=="
+      },
+      "VDS.Common": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "fFYBEVmVlyoeq2dhjM8OR3OCr+ZNCL8E7nEePCZyH2BVo3ky5lHZZiF0PcWwOJmRTyIA/6c0716DfHKNB5oKKg=="
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds LLM-powered entity extraction (via Microsoft.Extensions.AI) and W3C-standard RDF serialization (via dotNetRDF) to the AI Memex knowledge graph.

### What's new

| Component | Description |
|---|---|
| **EntityExtraction.fs** | MEAI \IChatClient\-based entity extraction with per-entry file caching |
| **RdfSerializer.fs** | dotNetRDF → Turtle (\graph.ttl\) + JSON-LD (\graph.jsonld\) |
| **ontology/** | JSON-LD context, custom RDF vocabulary, extraction prompt |
| **6th edge layer** | \EntityMention\ edges from LLM-extracted entities |
| **Entity chips UI** | 'Entities Mentioned' section on entry pages |

### Architecture decisions

- **Microsoft.Extensions.AI 10.4**: Provider-agnostic \IChatClient\ abstraction — swap LLM providers by changing one line
- **GitHub Models**: \openai/gpt-4o-mini\ via \models.github.ai/inference\ with \GITHUB_TOKEN\
- **Graceful degradation**: No token = no LLM calls, site builds normally with structural-only graph
- **Cache-first**: Per-entry cache at \graph/cache/{slug}.v1.json\ — subsequent builds skip LLM entirely
- **dotNetRDF 3.5.0**: Active library for Turtle + JSON-LD 1.1 serialization

### Results

| Metric | Value |
|---|---|
| RDF triples | 1,159 |
| Output files | \graph.ttl\ (170KB) + \graph.jsonld\ (129KB) |
| Edge layers | 5 → 6 (+ EntityMention) |
| Build impact (no token) | ~0s |
| Build impact (cached) | ~0s |
| Files changed | 12 (+1,168 / -13) |

### NuGet packages added

- \Microsoft.Extensions.AI 10.4.*\
- \Microsoft.Extensions.AI.OpenAI 10.4.*\
- \dotNetRDF 3.*\

### Build verification

- \dotnet build\: ✅ (0 errors, 1 pre-existing FS1104 warning)
- \dotnet run\: ✅ (full site generation with RDF output)