### PR TITLE
Add Garmin-compatible GPX waypoint export for travel guides

### DIFF
--- a/Builder.fs
+++ b/Builder.fs
@@ -608,6 +608,19 @@ module Builder
                         printfn "⚠️  No GPX content generated for %s" collection.Title
                 | None -> 
                     () // No GPX file expected for this collection
+
+                // Generate and write Garmin-compatible waypoint-only GPX file (if applicable)
+                match paths.GarminGpxPath with
+                | Some garminPath ->
+                    let processor = Collections.CollectionProcessor.createCollectionProcessor collection
+                    match processor.GenerateGarminGpxFile data with
+                    | Some gpxContent ->
+                        File.WriteAllText(Path.Join(outputDir, garminPath), gpxContent)
+                        printfn "✅ Generated Garmin GPX file: %s" garminPath
+                    | None ->
+                        printfn "⚠️  No Garmin GPX content generated for %s" collection.Title
+                | None ->
+                    () // No Garmin GPX file expected for this collection
                 
                 printfn "✅ Built collection: %s (%d items)" collection.Title (data.Items.Length)
                 

--- a/Builder.fs
+++ b/Builder.fs
@@ -596,10 +596,12 @@ module Builder
                 let rssContent = Collections.CollectionBuilder.generateCollectionRssContent data
                 File.WriteAllText(Path.Join(outputDir, paths.RssPath), rssContent)
                 
+                // Build a single processor instance; reused by GPX + Garmin GPX blocks below.
+                let processor = Collections.CollectionProcessor.createCollectionProcessor collection
+
                 // Generate and write GPX file (if applicable)
                 match paths.GpxPath with
                 | Some gpxRelativePath ->
-                    let processor = Collections.CollectionProcessor.createCollectionProcessor collection
                     match processor.GenerateGpxFile data with
                     | Some gpxContent ->
                         File.WriteAllText(Path.Join(outputDir, gpxRelativePath), gpxContent)
@@ -612,7 +614,6 @@ module Builder
                 // Generate and write Garmin-compatible waypoint-only GPX file (if applicable)
                 match paths.GarminGpxPath with
                 | Some garminPath ->
-                    let processor = Collections.CollectionProcessor.createCollectionProcessor collection
                     match processor.GenerateGarminGpxFile data with
                     | Some gpxContent ->
                         File.WriteAllText(Path.Join(outputDir, garminPath), gpxContent)

--- a/Collections.fs
+++ b/Collections.fs
@@ -356,7 +356,9 @@ module CollectionProcessor =
                     Some (UTF8Encoding(false).GetString(ms.ToArray()))
             with
             | ex ->
-                printfn "Warning: Failed to generate Garmin GPX for %s: %s" collection.Title ex.Message
+                let travelDataPath = Path.Join("Data", collection.DataFile)
+                printfn "Warning: Failed to generate Garmin GPX for %s (data file: %s): %s"
+                    collection.Title travelDataPath ex.Message
                 None
         | _ -> None
 

--- a/Collections.fs
+++ b/Collections.fs
@@ -2,7 +2,9 @@ module Collections
 
 open System
 open System.IO
+open System.Text
 open System.Text.Json
+open System.Xml
 open Domain
 open Giraffe.ViewEngine
 
@@ -16,6 +18,7 @@ module CollectionProcessor =
         GenerateRssFeed: CollectionData -> string
         GenerateOpmlFile: CollectionData -> string
         GenerateGpxFile: CollectionData -> string option
+        GenerateGarminGpxFile: CollectionData -> string option
         GetOutputPaths: Collection -> CollectionPaths
     }
     
@@ -34,11 +37,18 @@ module CollectionProcessor =
             | Travel _ -> Some (Path.Join(baseDir, $"{collection.Id}.gpx"))
             | _ -> None
         
+        let garminGpxPath =
+            // Garmin fenix-compatible waypoint-only GPX, only for travel collections
+            match collection.CollectionType with
+            | Travel _ -> Some (Path.Join(baseDir, $"{collection.Id}-garmin.gpx"))
+            | _ -> None
+        
         {
             HtmlPath = Path.Join(baseDir, "index.html")
             RssPath = Path.Join(baseDir, "index.rss") 
             OpmlPath = Path.Join(baseDir, "index.opml")
             GpxPath = gpxPath
+            GarminGpxPath = garminGpxPath
             DataPath = Path.Join("Data", collection.DataFile)
         }
     
@@ -269,6 +279,87 @@ module CollectionProcessor =
         | _ ->
             None
     
+    // Generate Garmin fenix-compatible waypoint-only GPX 1.1 file.
+    //
+    // Output contract (per spec gist 0d7af14d39a05a8219faa7af86bc5ced):
+    //   - Root: <gpx version="1.1" creator="..." xmlns="http://www.topografix.com/GPX/1/1">
+    //   - Children: <wpt lat="..." lon="..."> with a single <name> child each
+    //   - NO <metadata>, <desc>, <cmt>, <sym>, <type>, <extensions>, <rte>, <rtept>,
+    //     <trk>, <trkseg>, <trkpt>
+    //   - Lat/lon validated to [-90,90] / [-180,180]; invalid points skipped with warning
+    //   - Empty/whitespace names get a "Waypoint NNN" fallback (1-based, zero-padded)
+    //   - Input order preserved
+    //
+    // Output is generated directly via XmlWriter (no string concatenation), so XML
+    // escaping (e.g., "Longman & Eagle" -> "Longman &amp; Eagle") is automatic.
+    let generateCollectionGarminGpx (data: CollectionData) : string option =
+        let collection = data.Metadata
+        let gpxNs = "http://www.topografix.com/GPX/1/1"
+        let creator = "Luis Quintanilla"
+
+        let isValidLatLon (lat: float) (lon: float) =
+            not (Double.IsNaN(lat) || Double.IsNaN(lon) || Double.IsInfinity(lat) || Double.IsInfinity(lon))
+            && lat >= -90.0 && lat <= 90.0
+            && lon >= -180.0 && lon <= 180.0
+
+        match collection.CollectionType with
+        | Travel _ ->
+            try
+                let travelDataPath = Path.Join("Data", collection.DataFile)
+                if not (File.Exists(travelDataPath)) then
+                    None
+                else
+                    let jsonContent = File.ReadAllText(travelDataPath)
+                    let travelData = JsonSerializer.Deserialize<TravelRecommendationData>(jsonContent)
+
+                    let settings = XmlWriterSettings(
+                                        Indent = true,
+                                        IndentChars = "  ",
+                                        Encoding = UTF8Encoding(false), // UTF-8 without BOM
+                                        OmitXmlDeclaration = false)
+
+                    use ms = new MemoryStream()
+                    use writer = XmlWriter.Create(ms, settings)
+                    writer.WriteStartDocument()
+                    writer.WriteStartElement("gpx", gpxNs)
+                    writer.WriteAttributeString("version", "1.1")
+                    writer.WriteAttributeString("creator", creator)
+
+                    let mutable written = 0
+                    let mutable sourceIndex = 0
+                    for place in travelData.Places do
+                        sourceIndex <- sourceIndex + 1
+                        if not (isValidLatLon place.Latitude place.Longitude) then
+                            printfn "⚠️  Garmin GPX (%s): skipping waypoint #%d (%s) — invalid coordinates lat=%f lon=%f"
+                                collection.Id sourceIndex place.Name place.Latitude place.Longitude
+                        else
+                            written <- written + 1
+                            let name =
+                                if String.IsNullOrWhiteSpace(place.Name) then
+                                    let fallback = sprintf "Waypoint %03d" written
+                                    printfn "⚠️  Garmin GPX (%s): waypoint #%d has empty name; using fallback %s"
+                                        collection.Id sourceIndex fallback
+                                    fallback
+                                else
+                                    place.Name.Trim()
+                            writer.WriteStartElement("wpt", gpxNs)
+                            writer.WriteAttributeString("lat", (place.Latitude.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)))
+                            writer.WriteAttributeString("lon", (place.Longitude.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)))
+                            writer.WriteStartElement("name", gpxNs)
+                            writer.WriteString(name)
+                            writer.WriteEndElement() // name
+                            writer.WriteEndElement() // wpt
+
+                    writer.WriteEndElement() // gpx
+                    writer.WriteEndDocument()
+                    writer.Flush()
+                    Some (UTF8Encoding(false).GetString(ms.ToArray()))
+            with
+            | ex ->
+                printfn "Warning: Failed to generate Garmin GPX for %s: %s" collection.Title ex.Message
+                None
+        | _ -> None
+
     // Create unified collection processor
     let createCollectionProcessor (collection: Collection) : CollectionProcessor = 
         {
@@ -277,6 +368,7 @@ module CollectionProcessor =
             GenerateRssFeed = generateCollectionRss
             GenerateOpmlFile = generateCollectionOpml
             GenerateGpxFile = generateCollectionGpx
+            GenerateGarminGpxFile = generateCollectionGarminGpx
             GetOutputPaths = getCollectionPaths
         }
 

--- a/Domain.fs
+++ b/Domain.fs
@@ -272,6 +272,7 @@ module Domain
         RssPath: string         // "/collections/blogroll/index.rss"
         OpmlPath: string        // "/collections/blogroll/index.opml"
         GpxPath: string option  // "/collections/travel/rome-favorites/rome-favorites.gpx"
+        GarminGpxPath: string option  // Garmin fenix-compatible waypoint-only GPX (e.g., rome-favorites-garmin.gpx)
         DataPath: string        // "/Data/blogroll.json"
     }
 

--- a/Views/TravelViews.fs
+++ b/Views/TravelViews.fs
@@ -15,12 +15,12 @@ let generateTravelCollectionPage (data: CollectionData) (travelData: TravelRecom
             p [] [ Text "Get these recommendations on your phone or watch for offline use:" ]
             
             div [ _class "download-options" ] [
-                div [ _class "download-buttons mb-2" ] [
-                    a [ _href $"{collection.Id}.gpx"; _class "btn btn-primary me-2 mb-2"; _download $"{collection.Id}.gpx" ] [
+                div [ _class "download-buttons" ] [
+                    a [ _href $"{collection.Id}.gpx"; _class "btn btn-primary"; _download $"{collection.Id}.gpx" ] [
                         i [ _class "bi bi-download me-1" ] []
                         Text "Download GPX"
                     ]
-                    a [ _href $"{collection.Id}-garmin.gpx"; _class "btn btn-primary mb-2"; _download $"{collection.Id}-garmin.gpx" ] [
+                    a [ _href $"{collection.Id}-garmin.gpx"; _class "btn btn-primary"; _download $"{collection.Id}-garmin.gpx" ] [
                         i [ _class "bi bi-smartwatch me-1" ] []
                         Text "Download for Garmin"
                     ]

--- a/Views/TravelViews.fs
+++ b/Views/TravelViews.fs
@@ -20,7 +20,7 @@ let generateTravelCollectionPage (data: CollectionData) (travelData: TravelRecom
                         i [ _class "bi bi-download me-1" ] []
                         Text "Download GPX"
                     ]
-                    a [ _href $"{collection.Id}-garmin.gpx"; _class "btn btn-outline-primary mb-2"; _download $"{collection.Id}-garmin.gpx" ] [
+                    a [ _href $"{collection.Id}-garmin.gpx"; _class "btn btn-primary mb-2"; _download $"{collection.Id}-garmin.gpx" ] [
                         i [ _class "bi bi-smartwatch me-1" ] []
                         Text "Download for Garmin"
                     ]

--- a/Views/TravelViews.fs
+++ b/Views/TravelViews.fs
@@ -12,21 +12,34 @@ let generateTravelCollectionPage (data: CollectionData) (travelData: TravelRecom
     let gpxDownloadSection = 
         div [ _class "travel-downloads mb-4" ] [
             h3 [] [ Text "Download for Your Trip" ]
-            p [] [ Text "Get these recommendations on your phone for offline use:" ]
+            p [] [ Text "Get these recommendations on your phone or watch for offline use:" ]
             
             div [ _class "download-options" ] [
-                a [ _href $"{collection.Id}.gpx"; _class "btn btn-primary me-2"; _download $"{collection.Id}.gpx" ] [
-                    i [ _class "bi bi-download me-1" ] []
-                    Text "Download GPX"
+                div [ _class "download-buttons mb-2" ] [
+                    a [ _href $"{collection.Id}.gpx"; _class "btn btn-primary me-2 mb-2"; _download $"{collection.Id}.gpx" ] [
+                        i [ _class "bi bi-download me-1" ] []
+                        Text "Download GPX"
+                    ]
+                    a [ _href $"{collection.Id}-garmin.gpx"; _class "btn btn-outline-primary mb-2"; _download $"{collection.Id}-garmin.gpx" ] [
+                        i [ _class "bi bi-smartwatch me-1" ] []
+                        Text "Download for Garmin"
+                    ]
                 ]
                 
                 div [ _class "download-help mt-2" ] [
-                    small [ _class "text-muted" ] [
-                        Text "Import this GPX file into "
+                    small [ _class "text-muted d-block mb-1" ] [
+                        Text "Import the standard GPX into "
                         a [ _href "https://osmand.net/"; _target "_blank" ] [ Text "OsmAnd" ]
                         Text ", "
                         a [ _href "https://maps.me/"; _target "_blank" ] [ Text "Maps.me" ]
                         Text ", or your preferred GPS app for offline navigation."
+                    ]
+                    small [ _class "text-muted d-block" ] [
+                        Text "For Garmin fēnix and compatible watches: copy the Garmin file to "
+                        code [] [ Text "GARMIN/NewFiles/" ]
+                        Text ", eject the watch, then find them under "
+                        strong [] [ Text "START → Navigate → Saved Locations" ]
+                        Text "."
                     ]
                 ]
             ]

--- a/Views/TravelViews.fs
+++ b/Views/TravelViews.fs
@@ -29,9 +29,9 @@ let generateTravelCollectionPage (data: CollectionData) (travelData: TravelRecom
                 div [ _class "download-help mt-2" ] [
                     small [ _class "text-muted d-block mb-1" ] [
                         Text "Import the standard GPX into "
-                        a [ _href "https://osmand.net/"; _target "_blank" ] [ Text "OsmAnd" ]
+                        a [ _href "https://osmand.net/"; _target "_blank"; _rel "noopener noreferrer" ] [ Text "OsmAnd" ]
                         Text ", "
-                        a [ _href "https://maps.me/"; _target "_blank" ] [ Text "Maps.me" ]
+                        a [ _href "https://maps.me/"; _target "_blank"; _rel "noopener noreferrer" ] [ Text "Maps.me" ]
                         Text ", or your preferred GPS app for offline navigation."
                     ]
                     small [ _class "text-muted d-block" ] [
@@ -76,10 +76,10 @@ let generateTravelCollectionPage (data: CollectionData) (travelData: TravelRecom
                                 a [ _href $"geo:{place.Latitude},{place.Longitude}"; _class "btn btn-sm btn-outline-primary me-1 d-none-desktop" ] [
                                     Text "📱 Open in App"
                                 ]
-                                a [ _href $"https://www.openstreetmap.org/?mlat={place.Latitude}&mlon={place.Longitude}&zoom=18"; _target "_blank"; _class "btn btn-sm btn-outline-secondary me-1" ] [
+                                a [ _href $"https://www.openstreetmap.org/?mlat={place.Latitude}&mlon={place.Longitude}&zoom=18"; _target "_blank"; _rel "noopener noreferrer"; _class "btn btn-sm btn-outline-secondary me-1" ] [
                                     Text "🗺️ OpenStreetMap"
                                 ]
-                                a [ _href $"https://maps.google.com/?q={place.Latitude},{place.Longitude}"; _target "_blank"; _class "btn btn-sm btn-outline-secondary" ] [
+                                a [ _href $"https://maps.google.com/?q={place.Latitude},{place.Longitude}"; _target "_blank"; _rel "noopener noreferrer"; _class "btn btn-sm btn-outline-secondary" ] [
                                     Text "🌍 Google Maps"
                                 ]
                             ]
@@ -133,7 +133,7 @@ let generateTravelCollectionPage (data: CollectionData) (travelData: TravelRecom
                                     | Some website ->
                                         span [ _class "info-item me-4 mb-1" ] [
                                             i [ _class "bi bi-globe me-1" ] []
-                                            a [ _href website; _target "_blank" ] [ Text "Website" ]
+                                            a [ _href website; _target "_blank"; _rel "noopener noreferrer" ] [ Text "Website" ]
                                         ]
                                     | None -> ()
                                 ]

--- a/_src/css/custom/components.css
+++ b/_src/css/custom/components.css
@@ -776,3 +776,51 @@ textarea.form-control {
     margin-bottom: var(--spacing-md);
   }
 }
+
+/* =====================================================
+   Travel Guide Downloads
+   Stacked button row that wraps on narrow screens
+   ===================================================== */
+
+.travel-downloads .download-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  align-items: center;
+}
+
+.travel-downloads .download-buttons .btn {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.travel-downloads .download-help small {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  line-height: 1.5;
+}
+
+.travel-downloads .download-help small + small {
+  margin-top: var(--spacing-xs);
+}
+
+.travel-downloads .download-help code {
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--border-radius-sm);
+  background: var(--code-background, rgba(0,0,0,0.08));
+  font-size: 0.875em;
+}
+
+@media (max-width: 480px) {
+  .travel-downloads .download-buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .travel-downloads .download-buttons .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/_src/resources/ai-memex/pattern-garmin-gpx-waypoint-strictness.md
+++ b/_src/resources/ai-memex/pattern-garmin-gpx-waypoint-strictness.md
@@ -1,0 +1,112 @@
+---
+title: "Garmin GPX Waypoint Strictness — Dual-Output Pattern"
+description: "Garmin fēnix watches require strict GPX 1.1 namespaced, waypoint-only files. Pattern for shipping a parallel Garmin variant alongside a richer GPX without regressing existing consumers."
+entry_type: pattern
+published_date: "2026-05-10 08:30 -05:00"
+last_updated_date: "2026-05-10 08:30 -05:00"
+tags: gpx, garmin, fenix, indieweb, travel-guides, fsharp, xmlwriter, static-site
+related_skill: write-ai-memex
+source_project: lqdev-me
+---
+
+## Context
+
+Travel guides on lqdev.me generate GPX files so readers can take recommendations
+offline in apps like OsmAnd or Maps.me. The original generator emitted a "rich"
+GPX with `<metadata>`, `<wpt>` containing `<desc>` and `<type>`, and a bare
+root `<gpx version="1.1" creator="...">` (no XML namespace).
+
+This worked fine for phone apps. **It did not work for a Garmin fēnix 6X.**
+
+## The gotcha
+
+The fēnix 6X waypoint importer (Saved Locations) is far stricter than phone
+apps. It rejects or silently drops files that:
+
+1. **Lack the GPX 1.1 namespace** on the root element. The official namespace
+   `xmlns="http://www.topografix.com/GPX/1/1"` must be present.
+2. Contain elements outside the minimal waypoint shape. The fēnix happiest path
+   is literally `<gpx>` → `<wpt lat lon>` → `<name>`. Anything else
+   (`<desc>`, `<sym>`, `<type>`, `<extensions>`, `<metadata>`, routes, tracks)
+   risks rejection.
+3. Have raw, unescaped ampersands in names (e.g., `Longman & Eagle`) — which
+   are an XML well-formedness violation regardless of device.
+
+## The pattern
+
+**Don't refactor the existing rich GPX. Ship a second, minimal variant beside
+it.** Different consumers need different fidelity; a static site can produce
+both for free.
+
+For each travel collection:
+
+```
+/collections/travel/<id>/
+├── <id>.gpx           ← rich (OsmAnd/Maps.me)
+└── <id>-garmin.gpx    ← minimal, namespaced (Garmin Saved Locations)
+```
+
+Surface both in the UI with distinct buttons. Make the broad-app one primary,
+the Garmin one secondary, and add literal copy/paste guidance for the watch:
+*"Copy to `GARMIN/NewFiles/`, then START → Navigate → Saved Locations."*
+
+## Implementation notes (F# / .NET)
+
+- **Generate via `XmlWriter`, not string concatenation.** XmlWriter handles all
+  XML escaping automatically (`&` → `&amp;`, etc.), so you get the spec's
+  "ampersand repair" requirement for free, with zero parsing.
+- **Watch the encoding.** `XmlWriter.Create(StringBuilder, …)` will emit
+  `<?xml version="1.0" encoding="utf-16"?>` because StringBuilder is UTF-16
+  internally — a mismatch with the UTF-8 file `File.WriteAllText` then writes.
+  Write to a `MemoryStream` with `XmlWriterSettings(Encoding = UTF8Encoding(false))`
+  and decode the bytes back to a string.
+- **Validate lat/lon at generation time** (`-90..90`, `-180..180`) and skip
+  invalid points with a build-time warning rather than emitting bad waypoints.
+- **Fallback for empty names.** Spec convention is `Waypoint NNN` (1-based,
+  zero-padded). The fēnix needs *something* in `<name>`; an empty element will
+  drop the waypoint silently.
+- **Use `CultureInfo.InvariantCulture`** when formatting coordinates to "F6" so
+  locales with comma decimal separators don't break the file.
+
+## Validation
+
+A reparse-and-assert test script (`dotnet fsi`) covers the spec's Definition of
+Done:
+
+- Root namespace = `http://www.topografix.com/GPX/1/1`
+- Forbidden elements absent (`metadata`, `desc`, `cmt`, `sym`, `type`,
+  `extensions`, `rte`, `rtept`, `trk`, `trkseg`, `trkpt`)
+- Every `<wpt>` has exactly one `<name>` child and no others
+- Lat/lon in valid ranges, input order preserved
+- `&` round-trips to `&amp;`
+- Declared encoding matches actual file encoding
+- Original rich GPX still present (no regression)
+
+## Why ship both instead of replacing the rich GPX
+
+OsmAnd and Maps.me users *benefit* from the descriptions and category metadata
+in the rich variant. Stripping the file down to satisfy Garmin would degrade
+the experience for the majority of users. Generation cost is negligible on a
+static build, so dual output is the right trade.
+
+## When this generalizes
+
+Any time a "lowest-common-denominator" device sits in the consumer set for a
+generated artifact (GPX, RSS, ICS, OPML, etc.), ask whether you should:
+
+1. Constrain the rich format to the strict subset, or
+2. Ship a second, minimal artifact alongside it.
+
+Option 2 is almost always right when the rich consumers outnumber the strict
+ones and generation is cheap. The cost is one extra button and one extra file
+per artifact.
+
+## References
+
+- Spec gist: <https://gist.github.com/lqdev/0d7af14d39a05a8219faa7af86bc5ced>
+- Files in this repo:
+  - `Collections.fs` — `generateCollectionGarminGpx`
+  - `Views/TravelViews.fs` — dual download buttons
+  - `test-scripts/test-garmin-gpx.fsx` — reparse + assertions
+- Related: [[pattern-content-volume-html-parsing]] (similar "different consumers,
+  different output" reasoning for HTML)

--- a/docs/travel-guide-howto.md
+++ b/docs/travel-guide-howto.md
@@ -218,11 +218,12 @@ Add your new guide to the main travel guides page in `_src/travel-guides.md`:
 
 The system automatically generates:
 
-1. **GPX File**: Waypoints for offline navigation apps
-2. **Map Links**: geo: URIs, OpenStreetMap, Google Maps
-3. **Category Icons**: Visual indicators for place types
-4. **Responsive Design**: Mobile-optimized layout
-5. **Download Section**: GPX download with app recommendations
+1. **GPX File**: Waypoints for offline navigation apps (rich; includes descriptions and categories)
+2. **Garmin GPX File**: Waypoint-only GPX 1.1 variant compatible with Garmin fēnix and similar watches
+3. **Map Links**: geo: URIs, OpenStreetMap, Google Maps
+4. **Category Icons**: Visual indicators for place types
+5. **Responsive Design**: Mobile-optimized layout
+6. **Download Section**: Both GPX downloads with app and watch instructions
 
 ### Mobile Integration
 
@@ -236,11 +237,33 @@ The system automatically generates:
 - GPX files include place descriptions
 - Practical info embedded in waypoints
 
+### Garmin fēnix / Wearable Integration
+
+The Garmin variant is a **waypoint-only** GPX 1.1 file with the official
+namespace and only `<gpx>` → `<wpt>` → `<name>` elements — the strict shape
+the fēnix 6X (and similar Garmin watches) require for Saved Locations.
+
+To load on a Garmin watch:
+
+1. Connect the watch via USB.
+2. Copy `[guide-id]-garmin.gpx` to the `GARMIN/NewFiles/` folder.
+3. Eject and disconnect.
+4. On the watch: **START → Navigate → Saved Locations**.
+
+Notes:
+- The waypoints appear under *Saved Locations*, not *Courses* (this file is
+  intentionally not a course/route/track).
+- For the current Chicago favorites guide, expect **18 waypoints** to load
+  (regression check — see `test-scripts/test-garmin-gpx.fsx`).
+- The original rich GPX (`[guide-id].gpx`) is unchanged and still preferred for
+  OsmAnd / Maps.me.
+
 ### URL Structure
 
 Travel guides follow a consistent URL pattern:
 - Main page: `/collections/travel/[guide-id]/`
 - GPX file: `/collections/travel/[guide-id]/[guide-id].gpx`
+- Garmin GPX file: `/collections/travel/[guide-id]/[guide-id]-garmin.gpx`
 - Travel index: `/collections/travel-guides/`
 
 ## Advanced Features

--- a/test-scripts/test-garmin-gpx.fsx
+++ b/test-scripts/test-garmin-gpx.fsx
@@ -1,0 +1,108 @@
+// test-scripts/test-garmin-gpx.fsx
+//
+// Validates the Garmin-compatible GPX output produced by Collections.fs against
+// the contract from gist 0d7af14d39a05a8219faa7af86bc5ced (Garmin fenix 6X
+// Saved Locations / Waypoints).
+//
+// Run from the repo root after `dotnet run` has produced _public/:
+//   dotnet fsi test-scripts/test-garmin-gpx.fsx
+
+open System
+open System.IO
+open System.Xml.Linq
+
+let repoRoot =
+    let here = __SOURCE_DIRECTORY__
+    Path.GetFullPath(Path.Combine(here, ".."))
+
+let gpxPath =
+    Path.Combine(repoRoot, "_public", "collections", "travel",
+                 "chicago-favorites", "chicago-favorites-garmin.gpx")
+
+if not (File.Exists gpxPath) then
+    eprintfn "❌ Garmin GPX not found at %s — run `dotnet run` first." gpxPath
+    exit 1
+
+let mutable failures = 0
+let assertTrue (label: string) (cond: bool) =
+    if cond then printfn "✅ %s" label
+    else
+        printfn "❌ %s" label
+        failures <- failures + 1
+
+let gpxNs = XNamespace.Get "http://www.topografix.com/GPX/1/1"
+
+// 1. Parses as XML
+let doc =
+    try Some (XDocument.Load gpxPath)
+    with ex ->
+        printfn "❌ Output XML did not parse: %s" ex.Message
+        None
+
+match doc with
+| None -> exit 1
+| Some doc ->
+    let root = doc.Root
+    assertTrue "Root is <gpx> in GPX 1.1 namespace" (root.Name = (gpxNs + "gpx"))
+    assertTrue "version=\"1.1\"" (root.Attribute(XName.Get "version").Value = "1.1")
+    assertTrue "creator attribute is non-empty"
+        (let a = root.Attribute(XName.Get "creator") in a <> null && not (String.IsNullOrWhiteSpace a.Value))
+
+    let waypoints = root.Elements(gpxNs + "wpt") |> Seq.toList
+    assertTrue "Chicago favorites produces 18 waypoints (per spec DoD)"
+        (waypoints.Length = 18)
+
+    // 2. Forbidden output elements absent
+    let forbidden = ["metadata"; "desc"; "cmt"; "sym"; "type"; "extensions";
+                     "rte"; "rtept"; "trk"; "trkseg"; "trkpt"]
+    for name in forbidden do
+        let found = doc.Descendants() |> Seq.exists (fun e -> e.Name.LocalName = name)
+        assertTrue (sprintf "Forbidden element <%s> absent" name) (not found)
+
+    // 3. Each <wpt> has exactly one <name> and no other children
+    let mutable allWptShapeOk = true
+    for wpt in waypoints do
+        let children = wpt.Elements() |> Seq.toList
+        if children.Length <> 1 || children.[0].Name <> (gpxNs + "name") then
+            allWptShapeOk <- false
+    assertTrue "Every <wpt> has exactly one <name> child" allWptShapeOk
+
+    // 4. Lat/lon valid
+    let mutable allCoordsValid = true
+    for wpt in waypoints do
+        let lat = float (wpt.Attribute(XName.Get "lat").Value)
+        let lon = float (wpt.Attribute(XName.Get "lon").Value)
+        if lat < -90.0 || lat > 90.0 || lon < -180.0 || lon > 180.0 then
+            allCoordsValid <- false
+    assertTrue "All waypoint coordinates within valid ranges" allCoordsValid
+
+    // 5. Order matches data file (just check the first and known-special waypoint)
+    let firstName = waypoints.[0].Element(gpxNs + "name").Value
+    assertTrue "First waypoint is Chicago Pizza and Oven Grinder Company"
+        (firstName = "Chicago Pizza and Oven Grinder Company")
+
+    // 6. Ampersand correctly escaped — Longman & Eagle is in the source data
+    let raw = File.ReadAllText gpxPath
+    assertTrue "Raw \"& \" (unescaped ampersand) absent from output"
+        (not (raw.Contains("Longman & Eagle")))
+    assertTrue "Properly escaped &amp; present"
+        (raw.Contains("Longman &amp; Eagle"))
+
+    // 7. XML declaration encoding matches actual file encoding (UTF-8)
+    assertTrue "XML declaration encoding=\"utf-8\""
+        (raw.IndexOf("encoding=\"utf-8\"", StringComparison.OrdinalIgnoreCase) > 0)
+
+    // 8. Original rich GPX still exists (we did not regress it)
+    let richPath = Path.Combine(repoRoot, "_public", "collections", "travel",
+                                 "chicago-favorites", "chicago-favorites.gpx")
+    assertTrue "Original rich GPX still present alongside Garmin variant"
+        (File.Exists richPath)
+
+if failures = 0 then
+    printfn ""
+    printfn "🎉 All Garmin GPX assertions passed."
+    exit 0
+else
+    printfn ""
+    printfn "❌ %d assertion(s) failed." failures
+    exit 1


### PR DESCRIPTION
## Summary

Adds a parallel **Garmin-compatible GPX waypoint** export for every travel guide, served beside the existing rich GPX. The fenix 6X (and similar Garmin watches) won't load our current rich GPX as Saved Locations because it lacks the GPX 1.1 namespace and includes elements outside the strict `<gpx>` -> `<wpt>` -> `<name>` shape the watch expects.

The original GPX is **byte-identical** to before — zero regression for OsmAnd / Maps.me users.

Spec: https://gist.github.com/lqdev/0d7af14d39a05a8219faa7af86bc5ced

## Approach

Generate the Garmin variant directly from the typed `TravelRecommendationData` via `System.Xml.XmlWriter` (no parsing/repair pipeline; we own the source). All XML escaping is automatic, so `Longman & Eagle` round-trips correctly to `Longman &amp; Eagle`.

For each travel collection:

```
/_public/collections/travel/<id>/
├── <id>.gpx           ← rich (unchanged)
└── <id>-garmin.gpx    ← new, GPX 1.1 namespaced, waypoint-only
```

UI gains a secondary `Download for Garmin` button alongside the existing primary download, with literal `GARMIN/NewFiles/` instructions.

## Files changed

- `Domain.fs` — `GarminGpxPath` on `CollectionPaths`
- `Collections.fs` — `generateCollectionGarminGpx` (XmlWriter, UTF-8 MemoryStream, lat/lon validation, `Waypoint NNN` fallback for empty names)
- `Builder.fs` — write the Garmin variant alongside the rich one
- `Views/TravelViews.fs` — second download button + watch instructions
- `test-scripts/test-garmin-gpx.fsx` — reparse + 22 assertions covering the spec's Definition of Done
- `docs/travel-guide-howto.md` — Garmin fenix subsection
- `_src/resources/ai-memex/pattern-garmin-gpx-waypoint-strictness.md` — captures the dual-output pattern

## Verification checklist

- [x] `dotnet build` clean (only the pre-existing `FS1104` warning in `ActivityPubBuilder.fs`)
- [x] `dotnet run` regenerates the site with both GPX files
- [x] Chicago favorites Garmin GPX contains exactly **18 waypoints** (per spec DoD)
- [x] Output reparses as valid XML, root namespace `http://www.topografix.com/GPX/1/1`
- [x] No forbidden elements (`metadata`, `desc`, `cmt`, `sym`, `type`, `extensions`, `rte`, `rtept`, `trk`, `trkseg`, `trkpt`)
- [x] `Longman & Eagle` correctly escaped to `Longman &amp; Eagle`
- [x] XML declaration encoding matches actual file encoding (UTF-8)
- [x] Original `chicago-favorites.gpx` unchanged
- [x] All 22 assertions in `test-scripts/test-garmin-gpx.fsx` pass

## Out of scope

- Standalone Python CLI from the spec (we have native build integration)
- Routes / tracks / courses (explicitly excluded by the spec)
- Refactor of the existing rich GPX generator
