### PR TITLE
docs(backlog): rewrite backlog to 2026-05 reality (DOC-4)

### DIFF
--- a/projects/backlog.md
+++ b/projects/backlog.md
@@ -1,596 +1,76 @@
 # Website Development Backlog
 
-*Last Updated: 2025-08-21*
+*Last Updated: 2026-05-29*
 
-This backlog drives the systematic architectural upgrade of the indieweb content management system. **Core infrastructure complete** - all 8 content types successfully migrated to unified GenericBuilder pattern with AST-based processing and custom block support. **Tag RSS feeds implemented** - 1,187 working tag feeds with proper category metadata. **RSS feed date accuracy achieved** - all feeds now show historical dates instead of current date fallbacks. **Content type landing page parity achieved** - all major content types now have proper landing pages following established patterns. **Development workflow modernization complete** - VS Code snippets fully aligned with current architecture. **Text-only site implementation COMPLETE** - accessibility-first universal design for 2G networks, flip phones, and minimalist preferences with comprehensive Phase 2 enhancements. **Timezone-aware date parsing COMPLETE** - comprehensive timezone information applied across all content with environment-independent feed ordering and build reliability.
+This backlog tracks open opportunities and in-flight work for the site. It is intentionally **concise** — full implementation history lives in [`../changelog.md`](../changelog.md) and detailed project logs in [`archive/`](archive/). Reusable patterns and research are captured in the [AI Memex](../_src/resources/ai-memex/).
 
-## 🎯 Current Status: All Major Infrastructure COMPLETE ✅
+## 🎯 Current Status
 
-**Architecture Excellence Achieved**: Complete IndieWeb content management system with unified GenericBuilder pattern, comprehensive RSS feed architecture, accessibility-first design, and production-grade timezone handling. All major architectural components successfully implemented and validated.
+The site is a mature, production IndieWeb static site generator (.NET 10, F#, Giraffe ViewEngine, Markdig). All core architecture is complete and stable:
 
-**Recent Completion**: Timezone-Aware Date Parsing Pattern implementation (2025-08-21) resolved critical feed ordering inconsistencies and environment dependency issues. System now provides reliable chronological ordering regardless of build machine timezone configuration.
+- **Unified content pipeline** — all content types flow through the `GenericBuilder` AST pattern with custom Markdig blocks.
+- **Feed architecture** — RSS/Atom/JSON + OPML across every content type, tag feeds, and an "Everything" unified feed.
+- **Search** — site-wide client-side search (Fuse.js) over the full content index. *(shipped)*
+- **Text-only site** — complete accessibility-first mirror at `/text/` (<50KB pages, WCAG 2.1 AA). *(shipped)*
+- **ActivityPub federation** — the site federates: inbox handling, response semantics, link attachments, pagination, RSVP responses, account migration. *(live, ongoing phases)*
+- **AI Memex** — AI-authored knowledge content type with build-time Knowledge Graph (`[[wikilinks]]`, backlinks, JSON-LD).
+- **Desert theme** — bespoke design system, Bootstrap-free, light/dark variants.
 
-**Infrastructure Achievement**: All 8 content types successfully migrated to unified GenericBuilder pattern with comprehensive feed architecture, tag-based RSS feeds (1,187 feeds), timezone-aware date parsing, major UI/UX transformation with desert theme foundation, progressive loading architecture, external library integration pattern, and **complete text-only accessibility implementation** all **COMPLETE**.
+`projects/active/` is intentionally empty — current multi-PR work is tracked per-session, not as a long-lived active-project file.
 
-**Production Readiness**: Architecture foundation provides robust, scalable, accessible IndieWeb site with universal compatibility, excellent content discoverability, reliable feed ordering, and comprehensive development workflow efficiency. System ready for advanced features, content expansion, or new project initiatives.
+## 🚧 In Flight
 
-## ✅ Recently Completed
+### Site Improvements 2026-05 — umbrella `feature/site-improvements-2026-05`
 
-### ✅ Timezone-Aware Date Parsing Implementation - COMPLETE  
-**Project**: Comprehensive Timezone-Aware Date Parsing Pattern Implementation  
-**Complexity**: Medium  
-**Duration**: 2025-08-21 (1 intensive session)  
-**Status**: ✅ COMPLETE - Environment-independent chronological ordering with systematic timezone data  
-**Priority**: HIGH (Critical bug fix + production reliability) → COMPLETE
+A bite-size-PR program executed against one umbrella branch, merged to `main` at phase boundaries (α → β → δ → γ).
 
-**Achievement Summary**:
-- ✅ **Systematic Content Enhancement**: Applied `-05:00` timezone to 2,444 date fields across 1,119 content files
-- ✅ **GenericBuilder.fs Architecture**: Updated sorting logic (Lines 885 & 1021) from `DateTime.Parse()` to `DateTimeOffset.Parse()` 
-- ✅ **PowerShell Automation**: Developed bulk processing tools for systematic content modification and duplicate pattern cleanup
-- ✅ **Production Bug Resolution**: Fixed "college football post at top" chronological ordering issue in RSS feeds
-- ✅ **Environment Independence**: Eliminated timezone dependency between local development and CI/CD build environments
-- ✅ **RSS Feed Reliability**: All feeds now display accurate chronological ordering regardless of build machine timezone
-- ✅ **Pattern Implementation**: Successfully applied Timezone-Aware Date Parsing Pattern documented in copilot-instructions.md
+- **α — Docs & backlog hygiene** *(in progress)*: archive completed-migration/implementation docs (done), refresh `docs/README.md` index (done), refresh this backlog (this change), fill AI Memex stubs.
+- **β — Foundations**: `/tools` directory page (personal "app store" of self-built browser extensions / PWAs), `/colophon` enhancements, and a shovel-ready issue to promote `OnlineRadioPlaylist` into a first-class **stations** content type (spec only, not implemented here).
+- **δ — Automation & polish**: GitHub Actions **stale-content sweep**, GitHub Actions **yearly retrospective** draft generator (can reuse the website-stats script; gets richer once scrobbling is live), and remaining text-only polish.
+- **γ — Now-playing & privacy** *(centerpiece, last)*: a `/now-playing` page driven by the self-hosted **[podcast-scrobbler](https://github.com/lqdev/podcast-scrobbler)** (ListenBrainz-compatible, DuckDB) via client-side fetch of CORS-exposed *aggregation* endpoints. Privacy is encoded structurally — aggregations are public, raw listens are token-gated. This work is the canonical example for two AI Memex pattern entries: **"private vault → public garden"** (PRIV-1) and **"aggregation as a privacy default"** (PRIV-2).
 
-**Technical Impact**: Enhanced feed system reliability, improved IndieWeb microformats2 compliance, eliminated environment-dependent date display issues, and established robust pattern for future timezone handling. Zero content information loss with comprehensive enhancement across all content types.
+> The scrobbler integration spans two repos: the site (`/now-playing` UI + fetch) and `podcast-scrobbler` (its own `feature/now-playing-integration` umbrella for CORS-exposed aggregation endpoints).
 
-### ✅ Text-Only Website Implementation - COMPLETE
-**Project**: Text-Only Website Implementation - Accessibility-First Universal Design  
-**Complexity**: Large  
-**Duration**: 2025-08-07 (Research + Phase 1 + Phase 2 comprehensive completion)  
-**Status**: ✅ COMPLETE - Comprehensive accessibility-first website with enhanced user experience  
-**Priority**: HIGH (Universal access + accessibility compliance + performance optimization) → COMPLETE
+## 📌 Open Opportunities (uncommitted)
 
-**Final Achievement Summary**:
-- ✅ **Phase 1 Foundation**: F# ViewEngine templates, textOnlyLayout, minimal CSS (4.5KB), complete `/text/` directory structure
-- ✅ **Phase 2 Enhancements**: Enhanced content processing, tag browsing (1,195 pages), archive navigation (70 pages), search functionality
-- ✅ **Content Generation**: 1,130 content pages + 1,195 tag pages + 70 archive pages successfully built
-- ✅ **Performance Excellence**: 7.6KB homepage, all pages under 50KB target, zero build performance impact
-- ✅ **Accessibility Complete**: WCAG 2.1 AA compliance, semantic HTML, keyboard navigation, screen reader optimization
-- ✅ **Universal Compatibility**: 2G networks, flip phones, assistive technology, minimalist preferences fully supported
+Ideas worth doing eventually. Not scheduled; promote to "In Flight" when picked up.
 
-**Technical Architecture Delivered**:
-- **TextOnlyViews.fs**: Complete view module with 14 view functions covering all browsing patterns
-- **TextOnlyBuilder.fs**: Site generation orchestration with enhanced content processing and build functions
-- **Enhanced Content Processing**: HTML-to-text conversion preserving semantic structure (headings, lists, code blocks)
-- **Tag Browsing System**: Complete tag-based navigation with sanitized URL paths and occurrence counts
-- **Archive Navigation**: Chronological browsing by year/month with intuitive content organization
-- **Search Functionality**: Form-based search with accessibility compliance and helpful instructions
-- **Build Integration**: Seamless F# architecture integration with zero performance degradation
+### Content discovery
+- **Response subtype landing pages** — dedicated `/reshares/`, `/replies/`, `/stars/` pages using the proven `buildBookmarksLandingPage` pattern. *(bookmarks landing page shipped; subtypes remain open)*
+- **Related content / "you might also like"** — leverage the existing tag index and Knowledge Graph edges.
+- **Tag organization** — hierarchy or curated topic clusters over the flat tag set.
 
-**User Experience Excellence**:
-- **Content Discovery**: Multiple browsing patterns (type-based, tag-based, chronological, search)
-- **Enhanced Readability**: Improved HTML-to-text conversion maintaining semantic meaning
-- **Navigation Consistency**: Breadcrumb navigation, clear page relationships, cross-site transitions
-- **Accessibility Priority**: Skip links, ARIA labels, semantic landmarks, keyboard navigation
-- **Performance Optimization**: Sub-50KB pages optimized for slow connections and low-end devices
+### Quantified self (privacy-gated)
+These are deliberately **deferred** until the listening/privacy primitives (γ above) prove the "private vault → public garden" model in production:
+- **Reading life** — currently partly covered by reviews; a dedicated surface could aggregate read-later → bookmarks → reviews.
+- **Watching life** — minimal today; low priority.
+- **Places / travel** — interesting but privacy-bounded; existing travel guides cover the public-facing slice.
+- **Scrobble granularity** — `/now-playing` ships at aggregate/crate-find granularity; per-listen detail is an optional later enhancement (display-only, no per-scrobble content entries).
 
-**Pattern Established**: Complete methodology for accessibility-first universal design using F# ViewEngine + semantic HTML + minimal CSS approach with comprehensive browsing functionality, enhanced content processing, and excellent user experience while maintaining performance excellence.
+### Tools & automation
+- **`/tools` evolution** — v1 is a curated directory of links (read-it-later extension, github-post PWA, rss extension, playlist-creator). Could grow into richer per-tool pages, install instructions, or hosted demos.
+- **Cross-posting / syndication** — WebSub support or POSSE automation building on the live ActivityPub layer.
+- **Build performance** — profile build/feed-generation if times regress.
 
-### ✅ VS Code Snippets Modernization - COMPLETE
-**Project**: VS Code Snippets Modernization - Domain.fs Alignment & Content Type Completeness  
-**Complexity**: Low  
-**Duration**: 2025-08-05 (Single session completion)  
-**Status**: ✅ Complete - Snippets fully aligned with current architecture and enhanced for modern workflow
+### Platform (discuss before acting)
+- Major IndieWeb protocol additions, dynamic/back-end capabilities, or analytics with data-collection implications — require explicit discussion of privacy trade-offs first.
 
-**Achievement Summary**:
-- ✅ Complete Domain.fs alignment with field name consistency and proper type structure matching
-- ✅ Date format standardization with consistent timezone formatting (`-05:00`) across all snippets
-- ✅ Tag format alignment converted from empty arrays to proper placeholder format with array syntax
-- ✅ Content type completeness with new review, album, and livestream snippets added
-- ✅ Enhanced existing snippets with numbered placeholders for efficient tab navigation
-- ✅ Content helper tools added (datetime, blockquote, code block, link snippets)
-- ✅ Build validation successful with no breaking changes
+## ✅ Recently Completed (since 2025-08)
 
-**Pattern Established**: Complete development workflow enhancement through standardized, Domain.fs-aligned snippets ensuring consistent metadata across all content types and reducing creation-time errors.
+Compact pointer list — see [`../changelog.md`](../changelog.md) for full entries.
 
-### ✅ Unified RSS Feed Architecture Enhancement - COMPLETE
-**Project**: Unified RSS Feed Enhancement - Pattern Consistency & Subscription Hub Integration  
-**Complexity**: Medium  
-**Duration**: 2025-08-05 (Single session completion)  
-**Status**: ✅ Complete - Unified feed properly exposed with consistent patterns and user-friendly access
+- **2026-02** — Review rendering: SVG star ratings, badge dedupe, gradient-ID collision fix
+- **2026-01** — ActivityPub Phases 4A (inbox handler), 5A (response semantics), 5B/5F (link attachments & pagination), 6A (RSVP); account migration; Azure SWA queue-trigger fix
+- **2025-11** — `Builder.fs` I/O helper refactoring
+- **2025-09** — Repository directory cleanup; untagged-content discovery system
+- **2025-08** — Azure SWA redirect migration; Azure Blob Storage migration; webmention modernization + timezone-aware date parsing; composable starter-pack system; content structure reorganization; response-type badge specificity; numerous text-only and timeline UX fixes
 
-**Achievement Summary**:
-- ✅ Prominent "Everything Feed" placement in subscription hub as first Featured Feed
-- ✅ Pattern consistency alignment changing unified feed from /feed/index.xml to /feed/feed.xml
-- ✅ User-friendly /all.rss alias for easy subscription and sharing
-- ✅ OPML integration with "Everything" feed entry as first item in feeds.json
-- ✅ Backward compatibility maintenance with dual file generation
-- ✅ Complete feed architecture consistency across all 9 content types + unified feed
+**Foundational milestones (complete, stable):** unified GenericBuilder migration of all content types · unified + tag RSS feed architecture · enhanced content discovery (search) · text-only accessibility site · desert theme design system · progressive loading for high content volumes · URL alignment ("Cool URIs don't change").
 
-**Pattern Established**: Complete unified feed architecture following consistent URL patterns (/[type]/feed.xml → /[alias].rss) with prominent subscription hub integration solving feed discoverability challenges.
+## 🧭 Decision Framework
 
-### ✅ Bookmarks Landing Page Implementation - COMPLETE
-**Project**: Proper Bookmarks Landing Page Following Established Content Type Patterns  
-**Complexity**: Low  
-**Duration**: 2025-08-04 (Single session completion)  
-**Status**: ✅ Complete - 283 bookmark responses properly displayed with landing page parity
+Used when triaging new ideas (per the autonomous-partnership conventions):
 
-**Achievement Summary**:
-- ✅ Pattern consistency with notes and responses landing page structure
-- ✅ Updated CollectionViews.fs bookmarkView with proper header and description
-- ✅ Created buildBookmarksLandingPage function filtering bookmark-type responses
-- ✅ Integrated with existing unified feed system and build orchestration
-- ✅ Generated `/bookmarks/index.html` with 283 bookmark responses in chronological order
-- ✅ Maintained response-based approach leveraging existing content infrastructure
-
-**Pattern Established**: Complete methodology for content type landing pages ensuring discoverability and user experience consistency across all content types.
-
-## 🔮 Next Logical Development Opportunities
-
-**Architecture Status**: Complete content type infrastructure + comprehensive text-only accessibility implementation + proven UI patterns + external library integration + progressive loading + modernized development workflow → **Production-ready modern IndieWeb site with universal access and excellent user experience**.
-
-**Potential Next Phases** (autonomous analysis):
-
-### 🟡 YELLOW - Advanced Features (Propose with Rationale)
-1. **Advanced Search Enhancement**: Full-text indexing, content faceting, or enhanced search relevance
-2. **Performance Optimization**: Service workers for offline capability, advanced compression strategies
-3. **Content Syndication Enhancement**: WebSub support, advanced RSS features, cross-posting automation
-4. **Multi-format Support**: EPUB generation, PDF exports, or additional accessible formats
-5. **Analytics Integration**: Privacy-first analytics, content performance insights, user experience metrics
-
-### 🟡 YELLOW - User Experience Enhancement (Propose with Rationale)  
-1. **Advanced Navigation**: Content series detection, related content suggestions, reading progress
-2. **Personalization Features**: Reading preferences, content filtering, customizable interfaces
-3. **Interactive Enhancements**: Progressive enhancement with optional JavaScript features
-4. **Mobile App Companion**: PWA features, mobile-specific optimizations
-5. **Community Features**: Comment systems, webmention enhancements, social interactions
-
-### 🟡 YELLOW - Content Management Enhancement (Propose with Rationale)
-1. **Editorial Workflow**: Content scheduling, draft management, editorial calendars
-2. **Content Migration Tools**: Import from other platforms, batch content processing
-3. **Media Management**: Advanced image processing, media optimization, CDN integration
-4. **Content Analytics**: Popular content identification, content gap analysis
-5. **Automation Enhancement**: Advanced build optimizations, deployment automation
-
-### 🔴 RED - Major Architectural Decisions (Discuss Before Acting)
-1. **Platform Migration**: Moving to different hosting, major technology changes
-2. **Database Integration**: Adding dynamic content capabilities, user accounts
-3. **Monetization Features**: Subscription systems, premium content, commerce integration
-4. **Enterprise Features**: Multi-user support, advanced permissions, enterprise integrations
-
-**Autonomous Recommendation**: Continue with content creation and user testing of current comprehensive architecture. Monitor usage patterns and user feedback to identify highest-value enhancement opportunities. Current foundation provides excellent base for any future development direction.
-
-## ✅ Completed Infrastructure (All COMPLETE)
-
-### ✅ External Library Integration Pattern - COMPLETE
-**Project**: External JavaScript Library Integration Architecture  
-**Complexity**: Medium  
-**Duration**: 2025-07-27 (1 focused implementation session)  
-**Status**: ✅ Complete - Proven pattern established for future external libraries
-
-**Achievement Summary**:
-- ✅ Container-relative sizing (`width: 100%`) vs viewport-based (`75vw`) for proper bounds respect
-- ✅ Conditional loading via DOM detection (`document.querySelector()`) for performance optimization
-- ✅ Static asset management with public root deployment (`/lib/`) for proper path resolution
-- ✅ Minimal CSS interference philosophy allowing libraries to handle their own styling
-- ✅ Layout pattern consistency with individual content pages (snippetPageView, wikiPageView, etc.)
-- ✅ Reveal.js integration as working example with embedded configuration
-
-**Pattern Established**: Complete methodology for integrating external JavaScript libraries while maintaining content architecture consistency and performance optimization.
-
-### ✅ Progressive Loading Architecture - COMPLETE
-**Project**: Static Site Progressive Loading for High Content Volumes  
-**Complexity**: Medium  
-**Duration**: 2025-07-26 (1 intensive implementation session)  
-**Status**: ✅ Complete - Production-ready handling of 1000+ content items
-
-**Achievement Summary**:
-- ✅ Safe initial load (50 items) preventing HTML parser failures discovered in content volume research
-- ✅ Progressive chunks (25 items) with intersection observer + manual "Load More" button
-- ✅ Server-side JSON generation with comprehensive escaping for JavaScript consumption
-- ✅ Filter integration ensuring progressive content respects current filter state
-- ✅ Smooth animations with staggered reveals (50ms per item) for delightful user experience
-- ✅ TimelineProgressiveLoader class managing progressive loading state and error handling
-
-**Architecture Impact**: Solves critical content volume vs HTML parser stability challenge while maintaining excellent user experience on static sites.
-
-### ✅ Content Volume HTML Parsing Pattern - COMPLETE
-**Project**: Critical Browser Parsing Discovery & Documentation  
-**Complexity**: High (Research Discovery)  
-**Duration**: 2025-07-26 (debugging breakthrough session)  
-**Status**: ✅ Complete - Pattern documented in copilot-instructions.md
-
-**Critical Discovery**:
-- ✅ High content volumes (1000+ items) with `rawText` rendering can break browser DOM parsing entirely
-- ✅ Symptoms: Script tags in source but not Network tab, zero JavaScript execution
-- ✅ Root cause: Malformed HTML exceeding browser parser limits before script loading
-- ✅ Solution pattern: Progressive loading vs artificial content limits
-- ✅ Implementation pattern: Content limiting for testing, progressive strategy for production
-
-**Knowledge Integration**: Added to Technical Standards section of copilot-instructions.md as proven pattern for future high-volume content projects.
-
-### ✅ UI/UX Desert Theme Foundation - COMPLETE
-**Project**: Personal Design System with IndieWeb Preservation  
-**Complexity**: Large  
-**Duration**: 2025-07-26 (Phase 1-2 complete)  
-**Status**: ✅ Complete - Foundation ready for production integration
-
-**Phase 1-2 Achievement Summary**:
-- ✅ **Desert Color System**: Production-ready palette (Desert Sand, Saguaro Green, Sunset Orange) with accessibility
-- ✅ **Bootstrap Elimination**: 96% bundle size reduction with framework dependency removal  
-- ✅ **CSS Custom Properties**: Theme system with semantic naming and light/dark variants
-- ✅ **Always-Visible Navigation**: Desert-themed sidebar with perfect text visibility and mobile optimization
-- ✅ **IndieWeb Preservation**: All microformats2 markup (h-entry, h-card, p-category) maintained
-- ✅ **Accessibility Excellence**: WCAG 2.1 AA compliance with reduced motion and high contrast support
-
-**Architecture Ready**: Complete CSS foundation and navigation system ready for individual content page integration.
-
-### ✅ RSS Feed Historical Date Enhancement - COMPLETE
-**Project**: RSS Feed Date Accuracy Using Git History  
-**Complexity**: Medium  
-**Duration**: 2025-07-25 (1 session)
-**Status**: ✅ Complete - All feeds show historical dates
-
-**Achievement Summary**:
-- ✅ Git history extraction implemented for retroactive date addition
-- ✅ 32 files updated with historical dates across 4 content types
-- ✅ RSS processors fixed to use conditional pubDate without DateTime.Now fallbacks
-- ✅ URL structures corrected in all feed processors
-- ✅ Consistent timezone formatting (-05:00) across all content types
-- ✅ Date range spans 2021-2025 based on actual Git history
-
-### ✅ Tag RSS Feeds Implementation - COMPLETE
-**Project**: Tag RSS Feed Generation  
-**Complexity**: Low  
-**Duration**: 2025-07-25 (1 session)
-**Status**: ✅ Complete - 1,187 working tag feeds
-
-**Achievement Summary**:
-- ✅ RSS feeds available for all tags at `/tags/{tagname}/feed.xml`
-- ✅ Category elements added to all content type processors
-- ✅ Unified infrastructure leveraged for consistency
-- ✅ All 8 content types included in tag-based filtering
-- ✅ RSS 2.0 compliance maintained
-
-### ✅ Repository Hygiene & Legacy Cleanup - COMPLETE
-**Project**: Development Environment Optimization  
-**Complexity**: Low  
-**Duration**: 2025-07-25 (1 session)
-**Status**: ✅ Complete - Clean workspace achieved
-
-**Achievement Summary**:
-- ✅ 15 obsolete files removed (debug scripts, logs, migration artifacts)
-- ✅ 124MB disk space recovered
-- ✅ Build performance improved 79% (6.3s → 1.3s)
-- ✅ Active directory cleaned, proper project archival
-- ✅ Zero technical debt remaining
-
-### ✅ URL Alignment & Feed Discovery Optimization - COMPLETE
-**Project**: Website URL Structure & Feed Discovery  
-**Complexity**: Medium  
-**Duration**: 2025-01-13 → 2025-07-24
-**Status**: ✅ Complete - Archived in `projects/archive/url-alignment-comprehensive.md`
-
-**Achievement Summary**:
-- ✅ All URLs aligned with W3C "Cool URIs don't change" principles
-- ✅ Research-backed feed discovery optimization (content-proximate placement) implemented
-- ✅ Semantic separation between content, collections, and resources complete
-- ✅ Full IndieWeb compliance with microformats2 markup and webmention compatibility
-- ✅ Zero broken links with comprehensive 301 redirect strategy (20 mappings)
-- ✅ 82% better feed discoverability through content-proximate placement
-
-### ✅ Legacy Code Removal & Builder.fs Cleanup - COMPLETE  
-**Project**: Website Architecture Upgrade - Final Cleanup  
-**Complexity**: Medium  
-**Duration**: 2025-07-24 (1 focused day)
-**Status**: ✅ Complete - Archived in `projects/archive/legacy-code-cleanup.md`
-
-**Achievement Summary**:
-- ✅ 445+ lines of legacy code removed (FeatureFlags, MigrationUtils, RssService modules)
-- ✅ 25+ migration test scripts cleaned up
-- ✅ Build process streamlined (3.9s build times)
-- ✅ Zero technical debt remaining from migration phase
-- ✅ All unused functions and imports removed
-- ✅ Main build orchestration optimized for clarity
-
-## ✅ Completed Infrastructure (Archived)
-
-### Core Architecture Migrations - ALL COMPLETE
-All foundational infrastructure successfully implemented and deployed:
-
-- ✅ **Phase 1**: Core Infrastructure (GenericBuilder, AST processing, custom blocks)
-- ✅ **Phase 2**: All 8 Content Type Migrations (Snippets → Wiki → Presentations → Books → Posts → Notes → Responses → Albums)
-- ✅ **Phase 3**: Unified Feed System (single-pass processing, RSS 2.0 compliance)
-- ✅ **Phase 3.5**: Critical Fixes (presentation reveal.js slideshow restoration)
-
-**Architecture Achievement**: Builder.fs transformed from 20+ repetitive functions to unified GenericBuilder pattern. All content types process consistently through AST-based system with custom block support.
-
-**Migration Success**: 8 consecutive successful deployments using proven feature flag pattern. Zero regressions, all functionality preserved.  
----
-
-### ✅ Desert Theme Production Integration - COMPLETE
-**Project**: Individual Content Page Desert Theme Application  
-**Complexity**: Medium  
-**Duration**: 2025-07-26 → 2025-07-29 (Phase 4 complete)  
-**Status**: ✅ Complete - Production-ready modern IndieWeb site with personal desert aesthetic  
-**Priority**: HIGH → COMPLETE (All phases successful)
-
-**Production Implementation Complete**:
-- ✅ **Individual Content Pages**: All 8 content types apply desert theme with preserved IndieWeb microformats2 markup
-- ✅ **Navigation Consistency**: Desert theme sidebar and mobile navigation across all content types
-- ✅ **Cross-Content Integration**: Unified desert aesthetic from homepage to individual pages  
-- ✅ **Theme System Production**: Light/dark desert variants applied consistently throughout site
-- ✅ **External Library Integration**: Proven approach for specialized content (presentations, media)
-
-**Phase 4 Achievement Summary**:
-- ✅ **F# ViewEngine Integration**: All content types use `defaultIndexedLayout` with desert navigation
-- ✅ **CSS Architecture**: Complete `.individual-post` styling with desert color variables throughout
-- ✅ **IndieWeb Preservation**: Perfect microformats2 compliance across all individual content pages
-- ✅ **Webmention Integration**: Desert-themed webmention forms functional on all content types
-- ✅ **Responsive Excellence**: Mobile-optimized individual pages with proper sidebar transitions
-- ✅ **Performance Maintained**: Fast page loads with complete desert theme integration
-
-**Architecture Achievement**: Complete transformation from traditional blog to modern IndieWeb site with unified timeline, progressive loading, external library support, and personal desert aesthetic while preserving semantic web standards.
-
-## Autonomous Next Steps Analysis (Generated 2025-08-07)
-
-Following the copilot-instructions autonomous partnership framework, I've analyzed the current state with Text-Only Site Implementation active and identified logical progression opportunities:
-
-### 🎯 Active Project: Text-Only Site Implementation (HIGH Priority)
-
-#### Phase 1: Foundation Architecture Implementation
-**Current Status**: Research complete, project plan finalized, ready for Phase 1 implementation
-**Active Project**: Text-Only Website Implementation - Accessibility-First Universal Design
-**Timeline**: 3-4 weeks structured implementation following proven patterns
-
-**Phase 1 Objectives**:
-- **F# ViewEngine Templates**: Create text-only layout templates leveraging existing semantic HTML foundation
-- **Minimal CSS Implementation**: <5KB stylesheet targeting universal access and high contrast
-- **Directory Structure Setup**: Generate content in `_public/text/` with confirmed URL structure
-- **Navigation Architecture**: Text-only navigation mirroring main site structure for content parity
-
-**Implementation Benefits**:
-- Universal access for 2G networks, flip phones, and accessibility users
-- <50KB initial loads with full content parity validated through research
-- WCAG 2.1 AA compliance with semantic HTML foundation
-- Progressive enhancement methodology allowing graceful degradation
-
-### 🔬 Post-Implementation Opportunities (MEDIUM Priority)
-
-#### Text-Only Site Content Discovery Enhancement
-**Context**: Following text-only site implementation, content discovery patterns will need text-optimized approaches
-**Dependencies**: Text-Only Site Phase 1 complete
-
-**Discovery Opportunities**:
-- **Text-Only Search**: Lightweight search functionality without JavaScript dependencies
-- **Text-Only Archive Navigation**: Efficient temporal browsing optimized for minimal interfaces
-- **Text-Only Tag Discovery**: Tag-based content discovery with minimal bandwidth consumption
-- **Text-Only Feed Integration**: RSS feed discovery optimized for text-only experience
-
-#### Content Discovery Enhancement - Following Feed Architecture Success
-**Context**: Recent unified RSS feed architecture enhancement demonstrates the value of systematic content discovery improvements. With consistent feed patterns now established across all content types, the foundation exists for broader content discovery enhancements.
-
-**Opportunity Analysis**:
-- **Search Functionality**: No site search exists; users rely on navigation and tag browsing
-- **Content Cross-References**: Rich content exists but limited interconnection between related items
-- **Tag Organization**: 1,195 tag feeds exist but no hierarchical or categorical organization
-- **Content Recommendations**: No "related content" or "you might also like" functionality
-- **Archive Navigation**: Large content volume (1,129+ items) needs better historical browsing
-
-**Implementation Approach**:
-- Leverage existing tag infrastructure for content relationship mapping
-- Use established pattern consistency framework for search interface design
-- Apply progressive loading patterns for search results and archive browsing
-- Follow desert theme integration patterns for UI consistency
-
-**Estimated Impact**: Medium-High (significantly improves content discoverability and user engagement)
-
-#### Content Type Landing Page Enhancement - Extending Bookmark Pattern Success
-**Context**: Recent bookmarks landing page implementation following established content type patterns demonstrated clear methodology for improving content type discoverability. Several content types still need similar treatment.
-**Priority**: Deferred to post-text-only implementation for focused execution
-
-**Remaining Content Types**:
-- **Snippets Landing Page**: `/resources/snippets/` needs proper landing page beyond directory listing
-- **Wiki Landing Page**: `/resources/wiki/` needs enhanced organization and discovery
-- **Reviews Landing Page**: `/reviews/` needs consistent content type treatment
-- **Media Landing Page**: `/media/` needs proper album organization and preview
-
-**Implementation Benefits**:
-- Consistent content type experience across all 9 content types
-- Improved content discoverability through proper landing page structure
-- Enhanced user experience following established patterns
-- Better content organization and navigation
-
-**Estimated Impact**: Medium (completes content type landing page consistency)
-
-#### Performance Optimization - Following Progressive Loading Success
-**Context**: Progressive loading architecture successfully handles 1,129+ content items. Build performance shows 10+ second build times that could benefit from optimization analysis.
-**Priority**: Deferred to focus on text-only implementation - major performance gains already achieved
-
-**Optimization Opportunities**:
-- **Build Performance Analysis**: 10+ second build times may benefit from systematic optimization
-- **Tag Feed Generation**: 1,195 tag feeds generated could benefit from parallelization or caching
-- **Asset Optimization**: Static asset management and optimization review
-- **Progressive Loading Enhancement**: Extend progressive loading to additional content discovery interfaces
-
-**Implementation Approach**:
-- Build performance profiling and bottleneck identification
-- Implement caching strategies for frequently regenerated content
-- Optimize asset delivery and compression
-- Extend progressive loading patterns to search and archive interfaces
-
-**Estimated Impact**: Medium (improves development workflow and user experience)
-**Context**: Recent bookmarks landing page implementation following established content type patterns demonstrated clear methodology for improving content type discoverability. Several content types still need similar treatment.
-
-**Remaining Content Types**:
-- **Snippets Landing Page**: `/resources/snippets/` needs proper landing page beyond directory listing
-- **Wiki Landing Page**: `/resources/wiki/` needs enhanced organization and discovery
-- **Reviews Landing Page**: `/reviews/` needs consistent content type treatment
-- **Media Landing Page**: `/media/` needs proper album organization and preview
-
-**Implementation Benefits**:
-- Consistent content type experience across all 9 content types
-- Improved content discoverability through proper landing page structure
-- Enhanced user experience following established patterns
-- Better content organization and navigation
-
-**Estimated Impact**: Medium (completes content type landing page consistency)
-
-### Implementation Priority Framework
-
-**GREEN (Act Immediately)**:
-1. **Text-Only Site Phase 1**: F# ViewEngine templates and directory structure (active project priority)
-2. **Text-Only Site Content Parity**: Ensure all content accessible in text format (core requirement)
-
-**YELLOW (Propose with Rationale)**:
-1. **Text-Only Site Search**: Basic content search functionality for text-only experience (post-Phase 1)
-2. **Content Discovery Enhancement**: Site-wide search functionality for main site (leverages existing infrastructure)
-
-**RED (Discuss Before Acting)**:
-1. **Major IndieWeb Protocol Additions**: Affects external integration patterns (requires discussion)
-2. **Advanced Content Analytics Implementation**: Data collection and privacy considerations (requires discussion)
-
-This analysis prioritizes the active Text-Only Site Implementation while identifying logical post-implementation opportunities that build on successful architectural improvements and maintain focus on universal access and user experience enhancement.
-**Rationale**: With landing page parity achieved, the proven bookmark pattern can be applied to enhance content discovery significantly.
-
-**Response Subtype Landing Pages** (DEFERRED - Post text-only implementation):
-- **Reshare Landing Page**: 48+ reshare responses could benefit from dedicated discovery page
-- **Reply Landing Page**: 10+ reply responses for conversation-focused browsing  
-- **Star Landing Page**: 7+ starred items for favorite content discovery
-- **Implementation**: Direct application of `buildBookmarksLandingPage` pattern to other response types
-
-**Tag-Based Discovery Enhancement** (DEFERRED - Post text-only implementation):
-- **Popular Tag Landing Pages**: Leverage existing 1,187 tag RSS feeds for discovery pages
-- **Tag Intersection Pages**: Combined tag filtering for specialized content discovery
-- **Implementation**: Use existing tag infrastructure with CollectionViews pattern
-
-### [ ] Content Discovery Enhancement
-**Project**: Tag-Based and Collection Landing Pages  
-**Complexity**: Medium  
-**Estimated Effort**: 1-2 weeks  
-**Dependencies**: Text-Only Site Implementation (ACTIVE)  
-**Priority**: MEDIUM (Deferred to post-text-only implementation for focused execution)
-
-**Content Discovery Opportunities**:
-- **Tag Landing Pages**: Generate landing pages for popular tags using established content type filtering pattern
-- **Response Subtype Pages**: Create dedicated pages for reshares, replies, stars using bookmark pattern
-- **Temporal Landing Pages**: Year-based and monthly content aggregation pages
-- **Collection Enhancement**: Improve existing collection pages (blogroll, podroll) with better organization
-
-**Implementation Approach**:
-- Leverage proven `buildBookmarksLandingPage` pattern for consistent implementation
-- Use existing tag infrastructure and unified feed data for content aggregation
-- Apply established CollectionViews.fs patterns for consistent UI
-- Integrate with existing build orchestration in Program.fs
-
-**Success Criteria**:
-- [ ] Popular tags have dedicated landing pages with content lists
-- [ ] Response subtypes accessible through dedicated discovery pages  
-- [ ] Temporal browsing enables year/month-based content exploration
-- [ ] Enhanced collection pages improve content organization and discovery
-
-### [ ] Advanced Custom Blocks
-**Project**: Enhanced Block Features  
-**Complexity**: Medium  
-**Estimated Effort**: 2-3 weeks  
-**Dependencies**: Production Integration Complete
-
-**New Block Types**:
-- Enhanced `:::media` blocks with gallery support leveraging external library integration pattern
-- Advanced `:::review` blocks with structured metadata for filtering/search
-- `:::venue` blocks with location/mapping integration using proven external library approach
-- `:::event` blocks with calendar integration and RSVP support
-
-**Success Criteria**:
-- [ ] Gallery functionality in media blocks using external library pattern
-- [ ] Structured review data for filtering/search with desert theme integration
-- [ ] Venue blocks integrate with mapping services following container-relative sizing pattern
-- [ ] Event blocks generate calendar files with IndieWeb microformats2 preservation
-
-### [ ] Build Performance & Memory Optimization - LOWER PRIORITY
-**Project**: Build Performance & Memory Optimization  
-**Complexity**: Medium  
-**Priority**: LOWERED (UI/UX and progressive loading optimizations achieved significant improvements)  
-**Status**: 📝 Deferred - Major performance gains already achieved
-
-**Rationale for Lower Priority**: 
-- Progressive loading architecture solved content volume performance issues
-- Desert theme CSS elimination of Bootstrap achieved 96% bundle size reduction
-- Build time currently acceptable at ~10s for 1129 items with optimized static file copying
-- External library integration pattern optimized for conditional loading
-
-**Future Objectives** (if needed):
-- Implement parallel content processing where beneficial
-- Add build time metrics and performance monitoring
-- Investigate incremental build capabilities for development workflow
-
-**Current Baseline**: ~10s build time, 1129 items, optimized static file copying with lib/ directories  
-**Achieved Improvements**: 96% CSS bundle reduction, progressive loading, conditional script loading
-
----
-
-## Research Priority (Future Exploration)
-
-### [ ] Semantic Search Implementation
-**Project**: Content Search & Discovery  
-**Complexity**: Large  
-**Estimated Effort**: 3-4 weeks  
-**Dependencies**: Advanced Custom Blocks
-
-**Capabilities**:
-- Generate search indexes from all content types
-- Prepare content for vector embedding generation
-- Create fast client-side search interface
-- Implement semantic content discovery
-
-**Success Criteria**:
-- [ ] Comprehensive search data generation
-- [ ] Content prepared for embedding workflows
-- [ ] Fast, responsive search interface
-- [ ] Semantic content recommendations
-
-### [ ] Dynamic Feed Management
-**Project**: Client-Side Feed Customization  
-**Complexity**: Medium  
-**Estimated Effort**: 2-3 weeks  
-**Dependencies**: Semantic Search Implementation
-
-**Features**:
-- Real-time feed filtering and switching
-- User-customizable feed combinations
-- Interactive content discovery interface
-- Personalized content recommendations
-
-**Success Criteria**:
-- [ ] Dynamic feed filtering without page reloads
-- [ ] User preferences persist across sessions
-- [ ] Interactive content discovery tools
-- [ ] Personalized content curation
-
----
-
-## Backlog Management & Success Metrics
-
-### Current Architecture State
-**✅ Infrastructure Complete**: All 8 content types unified under GenericBuilder pattern with AST-based processing, custom block support, external library integration pattern, and progressive loading architecture.
-
-**🎯 Current Focus**: Desert theme production integration completing the architectural transformation from traditional blog to modern IndieWeb site with personal aesthetic.
-
-### Migration Methodology (8x Proven Pattern)
-- **Safety First**: Feature flags enable parallel system operation during transitions
-- **Validation Strategy**: Output comparison ensures identical results before legacy removal
-- **Continuous Testing**: Build and test after each change with comprehensive regression testing
-- **Documentation**: Complete project archival with lessons learned for future reference
-- **External Library Integration**: Proven pattern for JavaScript libraries with container-relative sizing
-- **Progressive Loading**: Established architecture for high-volume content without parser failures
-
-### Success Metrics Achieved
-- **Code Unification**: All content types process through single GenericBuilder pattern
-- **Performance**: Single-pass feed processing (65.6 items/sec across 1129 items) + 96% CSS bundle reduction
-- **Architecture Consistency**: Custom block system + external library pattern + progressive loading
-- **Zero Regressions**: All migrations completed with full functionality preservation + UI/UX transformation
-- **User Experience**: Desert theme with accessibility + progressive loading + external library integration
-- **Documentation**: Complete project history archived with proven methodologies + UI/UX patterns
-
-### Current Architecture Maturity
-**✅ Complete Infrastructure Stack**:
-- **Content Processing**: All 8 content types unified under GenericBuilder pattern with AST processing
-- **Feed Architecture**: Comprehensive RSS system with tag-based feeds (1,187 working feeds)
-- **UI/UX Foundation**: Desert theme CSS system with Bootstrap elimination and accessibility
-- **Progressive Loading**: Proven architecture handling 1000+ content items without browser parsing issues
-- **External Library Integration**: Established pattern for JavaScript libraries with conditional loading
-- **IndieWeb Compliance**: Full microformats2, webmentions, and semantic web standards preservation
-
-### Next Phase Focus
-**Production Integration**: Apply desert theme foundation to individual content pages completing the architectural transformation from traditional blog to modern IndieWeb site with personal aesthetic and proven performance patterns.
+- **🟢 GREEN** — obvious fixes, doc updates, logical next steps with clear benefit → act.
+- **🟡 YELLOW** — feature/architecture improvements → propose with rationale first.
+- **🔴 RED** — major architecture, platform, data-collection, or privacy-affecting changes → discuss before acting.

--- a/projects/backlog.md
+++ b/projects/backlog.md
@@ -16,7 +16,7 @@ The site is a mature, production IndieWeb static site generator (.NET 10, F#, Gi
 - **AI Memex** — AI-authored knowledge content type with build-time Knowledge Graph (`[[wikilinks]]`, backlinks, JSON-LD).
 - **Desert theme** — bespoke design system, Bootstrap-free, light/dark variants.
 
-`projects/active/` is intentionally empty — current multi-PR work is tracked per-session, not as a long-lived active-project file.
+`projects/active/` currently holds three **completed** ActivityPub phase docs (4A inbox handler, 5D dual-media, 6A RSVP) that are pending archival to [`archive/`](archive/); ongoing multi-PR work is otherwise tracked per session rather than as long-lived active-project files.
 
 ## 🚧 In Flight
 


### PR DESCRIPTION
## DOC-4 — Rewrite `projects/backlog.md`

Part of the α (docs hygiene) phase on umbrella `feature/site-improvements-2026-05`.

### Why
The backlog was **9 months stale** (dated 2025-08-21), internally contradictory (Text-Only listed as both COMPLETE *and* ACTIVE), had **verbatim-duplicated blocks** (e.g. the content-type landing-page section appeared twice), and made **false claims** — most notably `No site search exists` when site-wide search shipped, and no mention of the entire **ActivityPub federation** capability shipped Jan 2026.

### What changed (571 deletions → 51 insertions)
- **Current Status** now reflects shipped reality: search, text-only site, ActivityPub federation (Phases 4A/5A/5B/5F/6A + account migration), AI Memex Knowledge Graph.
- **In Flight** section added for this very umbrella (α docs hygiene → β /tools + /colophon + stations issue → δ GHA stale-sweep + retrospective → γ /now-playing + podcast-scrobbler + privacy primitives).
- **Open Opportunities** deduplicated and grounded against the filesystem: dropped items that already shipped (wiki/snippets/reviews/media landing pages now exist), kept genuinely-open ones (reshare/reply/star subtype pages), and parked quantified-self surfaces (reading/watching/places) behind the privacy primitives per the plan.
- **Recently Completed** is now a compact pointer list — full history defers to `changelog.md` and `projects/archive/` (no information lost).

### Validation
- All 4 relative links (changelog, archive, ai-memex, active) verified to resolve.
- Doc-only change — no build required.