### PR TITLE
fix(deps): regenerate FSharp.Core 10.1.300 hash in lock file (NU1403)

### DIFF
--- a/packages.lock.json
+++ b/packages.lock.json
@@ -26,7 +26,7 @@
         "type": "Direct",
         "requested": "[10.1.300, )",
         "resolved": "10.1.300",
-        "contentHash": "PICqprC6MSLTUHE3hZiJTIQcbuopdXYCiuoCg6/M5AN+Yx/c/72Dno6YAE6qEogyudhaEzDYwEwEXccHcCifXA=="
+        "contentHash": "0EIcInVrUNoZ2LmJ4zvXa4/9qXGPy3uUkM7DrrkKyajXw51fR+zpsvSrAGwvuAPudE0jGaTa2pl1TONR1V9UKw=="
       },
       "FSharp.Data": {
         "type": "Direct",


### PR DESCRIPTION
## Problem
`dotnet build` / `dotnet restore --locked-mode` fails on `main` with:

```text
error NU1403: Package content hash validation failed for FSharp.Core.10.1.300.
The package is different than the last restore.
```

The project uses `RestorePackagesWithLockFile`. Clearing the failing package, the HTTP cache, and then **all** NuGet caches (forcing a fresh download from source) did **not** resolve it — which per the documented playbook means **true lock drift** (the package content available from the source no longer matches the hash recorded in `packages.lock.json`), not local cache corruption.

## Fix
Followed `_src/resources/ai-memex/pattern-nuget-lock-hash-drift.md`: backed up the lock file, then `dotnet restore --force-evaluate`. It updated **exactly one** entry — the `FSharp.Core 10.1.300` `contentHash` (1 line changed). No dependency-graph changes.

```diff
- "contentHash": "PICqprC6MSLTUHE3hZiJTIQcbuopdXYCiuoCg6/M5AN+Yx/c/72Dno6YAE6qEogyudhaEzDYwEwEXccHcCifXA=="
+ "contentHash": "0EIcInVrUNoZ2LmJ4zvXa4/9qXGPy3uUkM7DrrkKyajXw51fR+zpsvSrAGwvuAPudE0jGaTa2pl1TONR1V9UKw=="
```

## Validation
- `dotnet build --no-restore` → **succeeded**, 0 errors (only the expected pre-existing `FS1104` warning in `ActivityPubBuilder.fs`).
- `dotnet run` → full site generated; Knowledge Graph processed all 56 Memex entries, search indexes built.

## Notes
Isolated, build-critical infra fix off `main` (not part of the `feature/site-improvements-2026-05` docs work). After this merges, I'll sync `main` → that umbrella so it picks up the fix too.
