### PR TITLE
feat: β phase — quick UI wins (FUND-2 /tools, FUND-4 /colophon)

### DIFF
--- a/Builder.fs
+++ b/Builder.fs
@@ -344,6 +344,12 @@ module Builder
         let saveDir = Path.Join(outputDir,"colophon")
         writePageToDir saveDir "index.html" colophonPage
 
+    let buildToolsPage () = 
+        let toolsContent = Path.Join(srcDir,"tools.md") |> convertFileToHtml |> contentView
+        let toolsPage = generate toolsContent "default" "Tools - Luis Quintanilla"
+        let saveDir = Path.Join(outputDir,"tools")
+        writePageToDir saveDir "index.html" toolsPage
+
     let buildContactPage () = 
         let contactContent = convertFileToHtml (Path.Join(srcDir,"contact.md")) |> contentView
         let contactPage = generate contactContent "default" "Contact - Luis Quintanilla"

--- a/Program.fs
+++ b/Program.fs
@@ -74,6 +74,7 @@ let main argv =
     buildTravelGuidesPage ()
     buildIRLStackPage ()
     buildColophonPage ()
+    buildToolsPage ()
     buildOnlineRadioPage ()
     buildResumePage ()
 

--- a/TextOnlyBuilder.fs
+++ b/TextOnlyBuilder.fs
@@ -88,6 +88,17 @@ let buildTextOnlyColophonPage (outputDir: string) =
     
     File.WriteAllText(outputPath, textColophonPage)
 
+let buildTextOnlyToolsPage (outputDir: string) =
+    let textToolsPage = TextOnlyViews.textOnlyToolsPage |> RenderView.AsString.htmlDocument
+    let outputPath = Path.Combine(outputDir, "text", "tools", "index.html")
+    
+    // Ensure directory exists
+    let dirPath = Path.GetDirectoryName(outputPath)
+    if not (Directory.Exists(dirPath)) then
+        Directory.CreateDirectory(dirPath) |> ignore
+    
+    File.WriteAllText(outputPath, textToolsPage)
+
 let buildTextOnlyHelpPage (outputDir: string) =
     let textHelpPage = TextOnlyViews.textOnlyHelpPage |> RenderView.AsString.htmlDocument
     let outputPath = Path.Combine(outputDir, "text", "help", "index.html")
@@ -287,6 +298,7 @@ let buildTextOnlySite (outputDir: string) (unifiedContent: UnifiedFeedItem list)
     buildTextOnlyContactPage outputDir
     buildTextOnlyUsesPage outputDir
     buildTextOnlyColophonPage outputDir
+    buildTextOnlyToolsPage outputDir
     buildTextOnlyHelpPage outputDir
     buildTextOnlyFeedsPage outputDir
     buildTextOnlyStarterPacksPages outputDir

--- a/Views/Layouts.fs
+++ b/Views/Layouts.fs
@@ -114,6 +114,7 @@ module Layouts
                         a [_class "dropdown-item"; _href "/resources/wiki"] [Text "Wiki"]
                         a [_class "dropdown-item"; _href "/resources/presentations"] [Text "Presentations"]
                         a [_class "dropdown-item"; _href "/resources/read-later"] [Text "Read Later"]
+                        a [_class "dropdown-item"; _href "/tools"] [Text "Tools"]
                         div [_class "dropdown-divider"] []
                         a [_class "dropdown-item"; _href "/resources/ai-memex/"] [Text "AI Memex"]
                     ]

--- a/Views/TextOnlyViews.fs
+++ b/Views/TextOnlyViews.fs
@@ -71,6 +71,7 @@ module TextOnlyContentProcessor =
             let linkMappings = [
                 ("/uses", "/text/uses/")
                 ("/colophon", "/text/colophon/")
+                ("/tools", "/text/tools/")
                 ("/contact", "/text/contact/")
                 ("/about", "/text/about/")
                 ("/feed", "/text/feeds/")
@@ -1050,3 +1051,27 @@ let textOnlyColophonPage =
         ]
     
     textOnlyLayout "Colophon" (RenderView.AsString.xmlNode contentHtml)
+
+// Tools Page
+let textOnlyToolsPage =
+    let markdownHtml = TextOnlyContentProcessor.loadMarkdownContent "tools.md"
+    let processedHtml = 
+        markdownHtml
+        |> TextOnlyContentProcessor.replaceImagesWithText 
+        |> TextOnlyContentProcessor.convertLinksToTextOnly
+    
+    let contentHtml =
+        div [] [
+            p [] [
+                a [_href "/text/"] [Text "← Back to Home"]
+                Text " | "
+                a [_href "/tools"] [Text "View Full Tools Page"]
+            ]
+            
+            // Rendered markdown content with text-only processing
+            div [_class "content"] [
+                rawText processedHtml
+            ]
+        ]
+    
+    textOnlyLayout "Tools" (RenderView.AsString.xmlNode contentHtml)

--- a/_src/colophon.md
+++ b/_src/colophon.md
@@ -22,9 +22,12 @@ In a gist, it's static web site built with .NET and hosted on Azure.
 
 I built the generator for this website myself. It's a .NET 10 console application built with [F#](https://dotnet.microsoft.com/languages/fsharp). The application depends on a few libraries:
 
-- [Markdig](https://www.nuget.org/packages/Markdig/) - Parse markdown content.
+- [Markdig](https://www.nuget.org/packages/Markdig/) - Parse markdown content, extended with custom block parsers for IndieWeb-style media, cards, and reviews.
 - [Giraffe.ViewEngine](https://www.nuget.org/packages/Giraffe.ViewEngine/) - Develop statically typed HTML using F#.
 - [YamlDotNet](https://www.nuget.org/packages/YamlDotNet/) - Parse markdown file front-matter formatted in YAML. The front matter provides details such as the publishing date, page title, and post type.
+- [dotNetRdf](https://www.nuget.org/packages/dotNetRdf/) - Build the site's [knowledge graph](/resources/ai-memex/) as RDF triples and emit JSON-LD.
+- [Microsoft.Extensions.AI](https://www.nuget.org/packages/Microsoft.Extensions.AI/) - AI-assisted entity extraction that powers the knowledge graph's connections.
+- [Net.Codecrete.QrCodeGenerator](https://www.nuget.org/packages/Net.Codecrete.QrCodeGenerator/) and [SkiaSharp](https://www.nuget.org/packages/SkiaSharp/) - Render a unique QR code for every page.
 
 ### Tooling
 
@@ -72,3 +75,7 @@ Webmentions are send as part of the site build and publish process. To help with
 #### Accepting Webmentions
 
 To accept Webmentions, I have an [Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-overview) endpoint which accepts POST requests and stores them in an [Azure Tables](https://learn.microsoft.com/azure/storage/tables/table-storage-overview) database. To help with validation and accepting Webmentions, I use the [WebmentionFs](https://www.nuget.org/packages/lqdev.WebmentionFs) library. For more details, see [Accept Webmentions using F#, Azure Functions, and RSS](/posts/receive-webmentions-fsharp-az-functions-fsadvent/).
+
+### Search
+
+The [search](/search) on this site runs entirely in your browser, with no server or third-party service. At build time the generator produces a JSON index of all content, and [Fuse.js](https://www.fusejs.io/) — a lightweight fuzzy-search library — handles matching client-side. Iconography across the site uses [Bootstrap Icons](https://icons.getbootstrap.com/).

--- a/_src/tools.md
+++ b/_src/tools.md
@@ -1,0 +1,53 @@
+# Tools
+
+Small, single-purpose tools I build for myself and share. They're the moving parts behind how I read, publish, and listen on the open web — capture what's interesting, publish to my own site first, and keep my media habits in formats I control.
+
+Everything here is open source and self-hostable or installable from source. No accounts, no tracking, your data stays yours.
+
+## Read It Later
+
+A minimal Chrome extension that saves the current page to a local-first reading list with zero organizational overhead — no folders, no tags, just a chronological list. Quick-capture via right-click or `Alt+Shift+R`, with a badge counter on the toolbar. Everything is stored locally in the browser and exports cleanly to JSON or Markdown, so it feeds straight into my [linkblog](/bookmarks/) workflow without any cloud middleman.
+
+- **Platform**: Chromium browsers (Manifest V3) · **Language**: JavaScript
+- **Solves**: Saving things to read later without handing my reading habits to a third party.
+- [github.com/lqdev/read-it-later-browser-extension](https://github.com/lqdev/read-it-later-browser-extension)
+
+## RSS Feed Detector
+
+A lightweight browser extension that automatically detects RSS and Atom feeds on any page and lets me subscribe in one click through my reader of choice (NewsBlur, Feedly, Inoreader, The Old Reader, or a custom URL pattern). The toolbar icon changes color and shows a badge when feeds are found, and feed URLs are one click to copy.
+
+- **Platform**: Chromium browsers (Manifest V3) · **Language**: JavaScript
+- **Solves**: Bringing feed discovery back to the browser now that sites have buried their RSS links.
+- [github.com/lqdev/rss-browser-extension](https://github.com/lqdev/rss-browser-extension)
+
+## GitHub Post Creator
+
+A small Progressive Web App that turns my phone's native share sheet into a publishing endpoint for this site. Share a page from any app and it drafts a bookmark or response as a commit to my GitHub repo — [POSSE](https://indieweb.org/POSSE) from anywhere, no native app required. It installs as a share target and works offline.
+
+- **Platform**: Installable PWA (share-target) · **Language**: HTML / JavaScript
+- **Solves**: Mobile publishing to my IndieWeb site straight from the OS share menu.
+- [github.com/lqdev/github-post-pwa](https://github.com/lqdev/github-post-pwa)
+
+## Playlist Creator
+
+A Python tool that converts Spotify playlists into portable formats — beautifully formatted Markdown documentation and M3U playlists, with optional YouTube links for VLC-compatible playback. It can also convert existing Markdown playlist files back to M3U, so a playlist becomes a durable, plain-text artifact instead of something locked inside one service.
+
+- **Platform**: CLI (`uv` / `pip`) · **Language**: Python
+- **Solves**: Getting playlists out of a walled garden and into formats I can archive and share.
+- [github.com/lqdev/playlist-creator](https://github.com/lqdev/playlist-creator)
+
+## Podcast TUI
+
+A cross-platform terminal user interface for managing podcasts — subscriptions with OPML import/export, parallel downloads, episode browsing, device sync, playlists, audio playback, discovery, tagging, and optional scrobbling. Keyboard-driven and fast, it's how I keep up with podcasts without a heavyweight app.
+
+- **Platform**: Terminal (cross-platform) · **Language**: Rust
+- **Solves**: A fast, ownable podcast client that lives in the terminal and speaks open formats.
+- [github.com/lqdev/podcast-tui](https://github.com/lqdev/podcast-tui)
+
+## Podcast Scrobbler
+
+A self-hosted, [ListenBrainz](https://listenbrainz.readthedocs.io/)-compatible scrobble server optimized for podcasts. It's a lightweight REST API that records what I listen to — episodes, timestamps, progress — and exposes aggregation endpoints (top podcasts, weekly stats). Built as a companion to Podcast TUI, but any ListenBrainz-compatible client can submit listens. This is the engine that will power a future `/now-playing` view here.
+
+- **Platform**: Self-hosted (Docker) · **Language**: C# / .NET 10 + DuckDB
+- **Solves**: Owning my listening history instead of renting it from a streaming platform.
+- [github.com/lqdev/podcast-scrobbler](https://github.com/lqdev/podcast-scrobbler)


### PR DESCRIPTION
## β phase — quick UI wins (boundary merge → main)

Bundles the two β-phase code changes from the umbrella branch into `main`.

### Included
- **FUND-2** (#2408): new `/tools` directory page listing my six personal tools, with full + text-only (`/text/tools/`) variants and a Resources-dropdown nav link.
- **FUND-4** (#2409): expanded `/colophon` built-with library list (dotNetRdf, Microsoft.Extensions.AI, QrCodeGenerator + SkiaSharp, Markdig custom blocks) and a new **Search** subsection (Fuse.js + Bootstrap Icons). Text-only colophon inherits automatically.

### Reference only (no code)
- **SPEC-1**: Stations content-type spec lives in issue #2410 (shovel-ready, includes RSS-semantics guidance). No code in this PR.

### Merge strategy
Merge via **merge commit** (not squash) to preserve the umbrella's commit history — the umbrella branch (`feature/site-improvements-2026-05`) stays alive for the δ phase. After merge, the umbrella is fast-forwarded to absorb the merge commit.

### Notes
`main` advanced with 3 content commits since the α boundary; they touch only `_src/notes` / `_src/responses` / `packages.lock.json` — **no overlap** with these code changes.