### PR TITLE
fix(text-only): correct content-type taxonomy (POL-3 P0)

### DIFF
--- a/TextOnlyBuilder.fs
+++ b/TextOnlyBuilder.fs
@@ -135,8 +135,8 @@ let buildTextOnlyAllContentPage (outputDir: string) (unifiedContent: UnifiedFeed
 let buildTextOnlyContentTypePages (outputDir: string) (unifiedContent: UnifiedFeedItem list) =
     let contentTypes = [
         "posts"; "notes"; "responses"; "snippets"; 
-        "wiki"; "presentations"; "reviews"; "albums";
-        "bookmarks"; "media"
+        "wiki"; "presentations"; "reviews"; "bookmarks";
+        "media"; "ai-memex"; "album-collection"; "playlist-collection"
     ]
     
     for contentType in contentTypes do
@@ -169,7 +169,7 @@ let buildTextOnlyIndividualPages (outputDir: string) (unifiedContent: UnifiedFee
                 let htmlContent = MarkdownService.convertMdToHtml presentation.Content
                 let textContentPage = TextOnlyViews.textOnlyPresentationPage presentation htmlContent |> RenderView.AsString.htmlDocument
                 let slug = TextOnlyViews.extractSlugFromUrl content.Url
-                let outputPath = Path.Combine(outputDir, "text", "content", content.ContentType.ToLower(), slug, "index.html")
+                let outputPath = Path.Combine(outputDir, "text", "content", TextOnlyViews.normalizeContentType content.ContentType, slug, "index.html")
                 
                 // Ensure directory exists
                 let dirPath = Path.GetDirectoryName(outputPath)
@@ -182,7 +182,7 @@ let buildTextOnlyIndividualPages (outputDir: string) (unifiedContent: UnifiedFee
                 let htmlContent = MarkdownService.convertMdToHtml content.Content
                 let textContentPage = TextOnlyViews.textOnlyContentPage content htmlContent |> RenderView.AsString.htmlDocument
                 let slug = TextOnlyViews.extractSlugFromUrl content.Url
-                let outputPath = Path.Combine(outputDir, "text", "content", content.ContentType.ToLower(), slug, "index.html")
+                let outputPath = Path.Combine(outputDir, "text", "content", TextOnlyViews.normalizeContentType content.ContentType, slug, "index.html")
                 
                 // Ensure directory exists
                 let dirPath = Path.GetDirectoryName(outputPath)
@@ -191,16 +191,18 @@ let buildTextOnlyIndividualPages (outputDir: string) (unifiedContent: UnifiedFee
                 
                 File.WriteAllText(outputPath, textContentPage)
         else
-            // For responses and bookmarks, content.Content already contains the CardHtml with target URL
-            // For other content types, convert markdown to HTML
+            // Responses, bookmarks, and reviews store pre-rendered CardHtml in content.Content
+            // (already HTML with target URL / review display); use it directly. All other
+            // content types store raw markdown that must be converted to HTML.
+            let normalizedType = TextOnlyViews.normalizeContentType content.ContentType
             let htmlContent = 
-                if content.ContentType = "responses" || content.ContentType = "bookmarks" then
-                    content.Content  // Already HTML with target URL display
+                if normalizedType = "responses" || normalizedType = "bookmarks" || normalizedType = "reviews" then
+                    content.Content  // Already HTML
                 else
                     MarkdownService.convertMdToHtml content.Content  // Convert markdown to HTML
             let textContentPage = TextOnlyViews.textOnlyContentPage content htmlContent |> RenderView.AsString.htmlDocument
             let slug = TextOnlyViews.extractSlugFromUrl content.Url
-            let outputPath = Path.Combine(outputDir, "text", "content", content.ContentType.ToLower(), slug, "index.html")
+            let outputPath = Path.Combine(outputDir, "text", "content", normalizedType, slug, "index.html")
             
             // Ensure directory exists
             let dirPath = Path.GetDirectoryName(outputPath)

--- a/Views/TextOnlyViews.fs
+++ b/Views/TextOnlyViews.fs
@@ -109,6 +109,18 @@ let parseItemDate (dateString: string) =
     | (true, date) -> date
     | (false, _) -> DateTime.MinValue
 
+// Normalize content-type values for text-only routing, filtering, and grouping.
+// The unified feed assigns response items their *subtype* (reply/reshare/star/rsvp)
+// as ContentType. For the text-only site we collapse those into a single "responses"
+// section (matching the main site) so individual pages, landing pages, and nav links
+// all resolve to the same consistent path.
+let normalizeContentType (contentType: string) =
+    if String.IsNullOrWhiteSpace(contentType) then ""
+    else
+        match contentType.ToLower() with
+        | "reply" | "reshare" | "star" | "rsvp" -> "responses"
+        | other -> other
+
 // Text-Only Homepage
 let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
     let recentItems = recentContent |> List.take (min 20 recentContent.Length)
@@ -133,7 +145,7 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]
@@ -152,13 +164,15 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
             ul [] [
                 li [] [a [_href "/text/content/posts/"] [Text "Blog Posts"]]
                 li [] [a [_href "/text/content/notes/"] [Text "Notes & Microblog"]]
-                li [] [a [_href "/text/content/responses/"] [Text "Responses & Bookmarks"]]
+                li [] [a [_href "/text/content/responses/"] [Text "Responses"]]
                 li [] [a [_href "/text/content/bookmarks/"] [Text "Bookmarks"]]
                 li [] [a [_href "/text/content/snippets/"] [Text "Code Snippets"]]
                 li [] [a [_href "/text/content/wiki/"] [Text "Wiki & Knowledge Base"]]
                 li [] [a [_href "/text/content/presentations/"] [Text "Presentations"]]
                 li [] [a [_href "/text/content/reviews/"] [Text "Book Reviews"]]
-                li [] [a [_href "/text/content/albums/"] [Text "Photo Albums"]]
+                li [] [a [_href "/text/content/album-collection/"] [Text "Albums"]]
+                li [] [a [_href "/text/content/playlist-collection/"] [Text "Playlists"]]
+                li [] [a [_href "/text/content/ai-memex/"] [Text "AI Memex"]]
                 li [] [a [_href "/text/content/media/"] [Text "Media & Files"]]
             ]
             
@@ -177,21 +191,24 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
 
 // Content Type Listing Page
 let textOnlyContentTypePage (contentType: string) (content: UnifiedFeedItem list) =
+    let normalizedRequestedType = normalizeContentType contentType
     let filteredContent = 
         content 
-        |> List.filter (fun item -> item.ContentType.ToLower() = contentType.ToLower())
+        |> List.filter (fun item -> normalizeContentType item.ContentType = normalizedRequestedType)
         |> List.sortByDescending (fun item -> parseItemDate item.Date)
     
     let pageTitle = 
-        match contentType.ToLower() with
+        match normalizedRequestedType with
         | "posts" -> "Blog Posts"
         | "notes" -> "Notes & Microblog"
-        | "responses" -> "Responses & Bookmarks"
+        | "responses" -> "Responses"
         | "snippets" -> "Code Snippets"
         | "wiki" -> "Wiki & Knowledge Base"
         | "presentations" -> "Presentations"
         | "reviews" -> "Book Reviews"
-        | "albums" -> "Photo Albums"
+        | "album-collection" -> "Albums"
+        | "playlist-collection" -> "Playlists"
+        | "ai-memex" -> "AI Memex"
         | "bookmarks" -> "Bookmarks"
         | "media" -> "Media & Files"
         | _ -> $"{contentType} Content"
@@ -217,7 +234,7 @@ let textOnlyContentTypePage (contentType: string) (content: UnifiedFeedItem list
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]
@@ -259,7 +276,7 @@ let textOnlyContentPage (content: UnifiedFeedItem) (htmlContent: string) =
             p [] [
                 a [_href "/text/"] [Text "← Home"]
                 Text " | "
-                a [_href $"/text/content/{content.ContentType.ToLower()}/"] [Text $"← All {content.ContentType}"]
+                a [_href $"/text/content/{normalizeContentType content.ContentType}/"] [Text $"← All {normalizeContentType content.ContentType}"]
                 Text " | "
                 a [_href content.Url] [Text "View Full Version"]
             ]
@@ -326,7 +343,7 @@ let textOnlyPresentationPage (presentation: Presentation) (htmlContent: string) 
 let textOnlyAllContentPage (content: UnifiedFeedItem list) =
     let groupedContent = 
         content
-        |> List.groupBy (fun item -> item.ContentType)
+        |> List.groupBy (fun item -> normalizeContentType item.ContentType)
         |> List.sortBy fst
     
     let contentHtml =
@@ -704,7 +721,7 @@ let textOnlyTagPage (tag: string) (content: UnifiedFeedItem list) =
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]
@@ -831,7 +848,7 @@ let textOnlyMonthlyArchivePage (year: int) (month: int) (content: UnifiedFeedIte
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]

--- a/Views/TextOnlyViews.fs
+++ b/Views/TextOnlyViews.fs
@@ -117,7 +117,7 @@ let parseItemDate (dateString: string) =
 let normalizeContentType (contentType: string) =
     if String.IsNullOrWhiteSpace(contentType) then ""
     else
-        match contentType.ToLower() with
+        match contentType.Trim().ToLowerInvariant() with
         | "reply" | "reshare" | "star" | "rsvp" -> "responses"
         | other -> other
 


### PR DESCRIPTION
## POL-3 (P0): Fix text-only content-type taxonomy

Fixes the P0 bugs found in the POL-3 text-only coverage audit. The text-only site assumed a stale/coarse content-type taxonomy that no longer matched the unified feed's **actual** `ContentType` values, producing empty landing pages, broken links, and orphaned pages.

### Root cause
The unified feed assigns response items their *subtype* (`reply`/`reshare`/`star`/`rsvp`) as `ContentType`, and uses `ai-memex` / `album-collection` / `playlist-collection` for newer types — but the text-only landing list, nav, and routing assumed `posts`/`notes`/`responses`/`albums`/etc.

### Bugs fixed (all empirically verified against generated `_public`)
| Before | After |
|---|---|
| `/text/content/responses/` landing **empty (0 items)** but linked from homepage nav; 807 responses orphaned under `/reply/`,`/reshare/`,`/rsvp/`,`/star/` with no landing | Single `/text/content/responses/` landing lists **all 807**; subtype dirs gone |
| `/text/content/albums/` landing **empty** but linked as "Photo Albums" | Dead entry removed; nav points to real `album-collection` ("Albums") |
| `ai-memex` (56), `album-collection` (2), `playlist-collection` (22) had individual pages but **no landing** | All three now have landing pages |
| `/text/content/` all-content page emitted **7 broken (404) landing links** | **Zero** broken landing links |
| Response/review individual pages **double-processed CardHtml as markdown** | Responses **and** reviews now use pre-rendered CardHtml directly |
| Individual response back-link → `/text/content/reshare/` (404) | → `/text/content/responses/` |

### Implementation
- New `normalizeContentType` helper in `TextOnlyViews.fs` collapses `reply`/`reshare`/`star`/`rsvp` → `responses` (matching the main site), applied **everywhere** a `/text/content/{type}/` URL is built, filtered, or grouped: homepage recent + Browse nav, content-type landing filter/links, individual-page back-link, all-content grouping, tag pages, monthly archive pages, and the individual-page output paths in `TextOnlyBuilder.fs`.
- `buildTextOnlyContentTypePages` content-type list updated to the real set (added `ai-memex`, `album-collection`, `playlist-collection`; removed dead `albums`).
- Individual-page HTML branch uses `content.Content` (pre-rendered HTML) for `responses`, `bookmarks`, **and** `reviews` (all store CardHtml); other types still convert markdown.

### Verification
- `dotnet build` — 0 errors (only the expected `FS1104`).
- `dotnet run` — site generates cleanly.
- Subtype dirs (`reply`/`reshare`/`rsvp`/`star`) **gone**; `responses` landing = 807/807.
- Zero broken landing links from `/text/content/`; **zero** stale `reply|reshare|rsvp|star|albums` links anywhere under `/text/`.
- All 12 homepage Browse-Content nav links resolve.

### Scope
P0 only. Section-parity gaps (radio/stations, resume, collections, streams, resources) are deferred to **#2418** per the audit decision.
