### PR TITLE
δ boundary: POL-3 text-only content-type taxonomy fix

### DIFF
--- a/TextOnlyBuilder.fs
+++ b/TextOnlyBuilder.fs
@@ -135,8 +135,8 @@ let buildTextOnlyAllContentPage (outputDir: string) (unifiedContent: UnifiedFeed
 let buildTextOnlyContentTypePages (outputDir: string) (unifiedContent: UnifiedFeedItem list) =
     let contentTypes = [
         "posts"; "notes"; "responses"; "snippets"; 
-        "wiki"; "presentations"; "reviews"; "albums";
-        "bookmarks"; "media"
+        "wiki"; "presentations"; "reviews"; "bookmarks";
+        "media"; "ai-memex"; "album-collection"; "playlist-collection"
     ]
     
     for contentType in contentTypes do
@@ -169,7 +169,7 @@ let buildTextOnlyIndividualPages (outputDir: string) (unifiedContent: UnifiedFee
                 let htmlContent = MarkdownService.convertMdToHtml presentation.Content
                 let textContentPage = TextOnlyViews.textOnlyPresentationPage presentation htmlContent |> RenderView.AsString.htmlDocument
                 let slug = TextOnlyViews.extractSlugFromUrl content.Url
-                let outputPath = Path.Combine(outputDir, "text", "content", content.ContentType.ToLower(), slug, "index.html")
+                let outputPath = Path.Combine(outputDir, "text", "content", TextOnlyViews.normalizeContentType content.ContentType, slug, "index.html")
                 
                 // Ensure directory exists
                 let dirPath = Path.GetDirectoryName(outputPath)
@@ -182,7 +182,7 @@ let buildTextOnlyIndividualPages (outputDir: string) (unifiedContent: UnifiedFee
                 let htmlContent = MarkdownService.convertMdToHtml content.Content
                 let textContentPage = TextOnlyViews.textOnlyContentPage content htmlContent |> RenderView.AsString.htmlDocument
                 let slug = TextOnlyViews.extractSlugFromUrl content.Url
-                let outputPath = Path.Combine(outputDir, "text", "content", content.ContentType.ToLower(), slug, "index.html")
+                let outputPath = Path.Combine(outputDir, "text", "content", TextOnlyViews.normalizeContentType content.ContentType, slug, "index.html")
                 
                 // Ensure directory exists
                 let dirPath = Path.GetDirectoryName(outputPath)
@@ -191,16 +191,18 @@ let buildTextOnlyIndividualPages (outputDir: string) (unifiedContent: UnifiedFee
                 
                 File.WriteAllText(outputPath, textContentPage)
         else
-            // For responses and bookmarks, content.Content already contains the CardHtml with target URL
-            // For other content types, convert markdown to HTML
+            // Responses, bookmarks, and reviews store pre-rendered CardHtml in content.Content
+            // (already HTML with target URL / review display); use it directly. All other
+            // content types store raw markdown that must be converted to HTML.
+            let normalizedType = TextOnlyViews.normalizeContentType content.ContentType
             let htmlContent = 
-                if content.ContentType = "responses" || content.ContentType = "bookmarks" then
-                    content.Content  // Already HTML with target URL display
+                if normalizedType = "responses" || normalizedType = "bookmarks" || normalizedType = "reviews" then
+                    content.Content  // Already HTML
                 else
                     MarkdownService.convertMdToHtml content.Content  // Convert markdown to HTML
             let textContentPage = TextOnlyViews.textOnlyContentPage content htmlContent |> RenderView.AsString.htmlDocument
             let slug = TextOnlyViews.extractSlugFromUrl content.Url
-            let outputPath = Path.Combine(outputDir, "text", "content", content.ContentType.ToLower(), slug, "index.html")
+            let outputPath = Path.Combine(outputDir, "text", "content", normalizedType, slug, "index.html")
             
             // Ensure directory exists
             let dirPath = Path.GetDirectoryName(outputPath)

--- a/Views/TextOnlyViews.fs
+++ b/Views/TextOnlyViews.fs
@@ -109,6 +109,18 @@ let parseItemDate (dateString: string) =
     | (true, date) -> date
     | (false, _) -> DateTime.MinValue
 
+// Normalize content-type values for text-only routing, filtering, and grouping.
+// The unified feed assigns response items their *subtype* (reply/reshare/star/rsvp)
+// as ContentType. For the text-only site we collapse those into a single "responses"
+// section (matching the main site) so individual pages, landing pages, and nav links
+// all resolve to the same consistent path.
+let normalizeContentType (contentType: string) =
+    if String.IsNullOrWhiteSpace(contentType) then ""
+    else
+        match contentType.Trim().ToLowerInvariant() with
+        | "reply" | "reshare" | "star" | "rsvp" -> "responses"
+        | other -> other
+
 // Text-Only Homepage
 let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
     let recentItems = recentContent |> List.take (min 20 recentContent.Length)
@@ -133,7 +145,7 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]
@@ -152,13 +164,15 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
             ul [] [
                 li [] [a [_href "/text/content/posts/"] [Text "Blog Posts"]]
                 li [] [a [_href "/text/content/notes/"] [Text "Notes & Microblog"]]
-                li [] [a [_href "/text/content/responses/"] [Text "Responses & Bookmarks"]]
+                li [] [a [_href "/text/content/responses/"] [Text "Responses"]]
                 li [] [a [_href "/text/content/bookmarks/"] [Text "Bookmarks"]]
                 li [] [a [_href "/text/content/snippets/"] [Text "Code Snippets"]]
                 li [] [a [_href "/text/content/wiki/"] [Text "Wiki & Knowledge Base"]]
                 li [] [a [_href "/text/content/presentations/"] [Text "Presentations"]]
                 li [] [a [_href "/text/content/reviews/"] [Text "Book Reviews"]]
-                li [] [a [_href "/text/content/albums/"] [Text "Photo Albums"]]
+                li [] [a [_href "/text/content/album-collection/"] [Text "Albums"]]
+                li [] [a [_href "/text/content/playlist-collection/"] [Text "Playlists"]]
+                li [] [a [_href "/text/content/ai-memex/"] [Text "AI Memex"]]
                 li [] [a [_href "/text/content/media/"] [Text "Media & Files"]]
             ]
             
@@ -177,21 +191,24 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
 
 // Content Type Listing Page
 let textOnlyContentTypePage (contentType: string) (content: UnifiedFeedItem list) =
+    let normalizedRequestedType = normalizeContentType contentType
     let filteredContent = 
         content 
-        |> List.filter (fun item -> item.ContentType.ToLower() = contentType.ToLower())
+        |> List.filter (fun item -> normalizeContentType item.ContentType = normalizedRequestedType)
         |> List.sortByDescending (fun item -> parseItemDate item.Date)
     
     let pageTitle = 
-        match contentType.ToLower() with
+        match normalizedRequestedType with
         | "posts" -> "Blog Posts"
         | "notes" -> "Notes & Microblog"
-        | "responses" -> "Responses & Bookmarks"
+        | "responses" -> "Responses"
         | "snippets" -> "Code Snippets"
         | "wiki" -> "Wiki & Knowledge Base"
         | "presentations" -> "Presentations"
         | "reviews" -> "Book Reviews"
-        | "albums" -> "Photo Albums"
+        | "album-collection" -> "Albums"
+        | "playlist-collection" -> "Playlists"
+        | "ai-memex" -> "AI Memex"
         | "bookmarks" -> "Bookmarks"
         | "media" -> "Media & Files"
         | _ -> $"{contentType} Content"
@@ -217,7 +234,7 @@ let textOnlyContentTypePage (contentType: string) (content: UnifiedFeedItem list
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]
@@ -259,7 +276,7 @@ let textOnlyContentPage (content: UnifiedFeedItem) (htmlContent: string) =
             p [] [
                 a [_href "/text/"] [Text "← Home"]
                 Text " | "
-                a [_href $"/text/content/{content.ContentType.ToLower()}/"] [Text $"← All {content.ContentType}"]
+                a [_href $"/text/content/{normalizeContentType content.ContentType}/"] [Text $"← All {normalizeContentType content.ContentType}"]
                 Text " | "
                 a [_href content.Url] [Text "View Full Version"]
             ]
@@ -326,7 +343,7 @@ let textOnlyPresentationPage (presentation: Presentation) (htmlContent: string) 
 let textOnlyAllContentPage (content: UnifiedFeedItem list) =
     let groupedContent = 
         content
-        |> List.groupBy (fun item -> item.ContentType)
+        |> List.groupBy (fun item -> normalizeContentType item.ContentType)
         |> List.sortBy fst
     
     let contentHtml =
@@ -704,7 +721,7 @@ let textOnlyTagPage (tag: string) (content: UnifiedFeedItem list) =
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]
@@ -831,7 +848,7 @@ let textOnlyMonthlyArchivePage (year: int) (month: int) (content: UnifiedFeedIte
                         let itemDate = parseItemDate item.Date
                         li [] [
                             h3 [] [
-                                a [_href $"/text/content/{item.ContentType.ToLower()}/{slug}/"] [
+                                a [_href $"/text/content/{normalizeContentType item.ContentType}/{slug}/"] [
                                     Text item.Title
                                 ]
                             ]


### PR DESCRIPTION
# δ boundary: POL-3 text-only content-type taxonomy fix

Lands the completed δ-phase work onto `main` via the umbrella branch. Boundary merges use a **merge commit** (not squash) to preserve umbrella history; the umbrella branch continues to live for any future phases.

## What's included

**POL-3 — Text-only site content-type taxonomy fix** (originally PR #2419)

The text-only site (`/text/`) assumed a stale, coarse content-type list. The unified feed actually assigns response items their *subtype* (`reply`/`reshare`/`star`/`rsvp`) as `ContentType`, and uses `ai-memex` / `album-collection` / `playlist-collection` for newer types. The mismatch produced:

- An empty `/text/content/responses/` landing and a dead `/albums/` landing (both linked from nav)
- 7 broken landing links from the all-content page
- ~887 orphaned individual pages
- Double-markdown-processing of pre-rendered `CardHtml` (responses/bookmarks/reviews)

### Fix
- Added `normalizeContentType` (collapses `reply`/`reshare`/`star`/`rsvp` → `responses`) and applied it across text-only URL construction, filtering, grouping, nav, tag pages, and monthly archives.
- Uses culture-invariant `Trim().ToLowerInvariant()` for stable, locale-independent routing (Copilot review follow-up).
- Updated the generated content-type list (removed dead `albums`; added `ai-memex`, `album-collection`, `playlist-collection`).
- Output paths normalized; HTML branch now uses pre-rendered `CardHtml` for responses/bookmarks/reviews instead of re-processing as markdown.

### Verified empirically against generated `_public/`
- `/text/content/responses/` = 807 items (was 0); subtype dirs gone
- New landings exist: album-collection (2), playlist-collection (22), ai-memex (56)
- Zero broken landing links; zero stale `reply`/`reshare`/`rsvp`/`star`/`albums` links under `/text/`; all 12 homepage nav links resolve

## Follow-ups filed (deferred, shovel-ready)
- **#2418** — text-only section parity for standalone static/utility pages (radio, collections, travel-guides, read-later, streams, resume), with per-section specs and worked patterns.
- **#2420** — sweep remaining culture-sensitive `.ToLower()` routing/grouping call sites to `ToLowerInvariant()`.

## Build
`dotnet build` — succeeds, 0 errors (only the known `FS1104` warning in `ActivityPubBuilder.fs`).
