### PR TITLE
feat(text-only): radio + collections + travel-guides pages + homepage discoverability (#2418 A/B/C)

### DIFF
--- a/TextOnlyBuilder.fs
+++ b/TextOnlyBuilder.fs
@@ -99,6 +99,39 @@ let buildTextOnlyToolsPage (outputDir: string) =
     
     File.WriteAllText(outputPath, textToolsPage)
 
+let buildTextOnlyRadioPage (outputDir: string) =
+    let textRadioPage = TextOnlyViews.textOnlyRadioPage |> RenderView.AsString.htmlDocument
+    let outputPath = Path.Combine(outputDir, "text", "radio", "index.html")
+    
+    // Ensure directory exists
+    let dirPath = Path.GetDirectoryName(outputPath)
+    if not (Directory.Exists(dirPath)) then
+        Directory.CreateDirectory(dirPath) |> ignore
+    
+    File.WriteAllText(outputPath, textRadioPage)
+
+let buildTextOnlyCollectionsPage (outputDir: string) =
+    let textCollectionsPage = TextOnlyViews.textOnlyCollectionsPage |> RenderView.AsString.htmlDocument
+    let outputPath = Path.Combine(outputDir, "text", "collections", "index.html")
+    
+    // Ensure directory exists
+    let dirPath = Path.GetDirectoryName(outputPath)
+    if not (Directory.Exists(dirPath)) then
+        Directory.CreateDirectory(dirPath) |> ignore
+    
+    File.WriteAllText(outputPath, textCollectionsPage)
+
+let buildTextOnlyTravelGuidesPage (outputDir: string) =
+    let textTravelGuidesPage = TextOnlyViews.textOnlyTravelGuidesPage |> RenderView.AsString.htmlDocument
+    let outputPath = Path.Combine(outputDir, "text", "collections", "travel-guides", "index.html")
+    
+    // Ensure directory exists
+    let dirPath = Path.GetDirectoryName(outputPath)
+    if not (Directory.Exists(dirPath)) then
+        Directory.CreateDirectory(dirPath) |> ignore
+    
+    File.WriteAllText(outputPath, textTravelGuidesPage)
+
 let buildTextOnlyHelpPage (outputDir: string) =
     let textHelpPage = TextOnlyViews.textOnlyHelpPage |> RenderView.AsString.htmlDocument
     let outputPath = Path.Combine(outputDir, "text", "help", "index.html")
@@ -301,6 +334,9 @@ let buildTextOnlySite (outputDir: string) (unifiedContent: UnifiedFeedItem list)
     buildTextOnlyUsesPage outputDir
     buildTextOnlyColophonPage outputDir
     buildTextOnlyToolsPage outputDir
+    buildTextOnlyRadioPage outputDir
+    buildTextOnlyCollectionsPage outputDir
+    buildTextOnlyTravelGuidesPage outputDir
     buildTextOnlyHelpPage outputDir
     buildTextOnlyFeedsPage outputDir
     buildTextOnlyStarterPacksPages outputDir

--- a/Views/TextOnlyViews.fs
+++ b/Views/TextOnlyViews.fs
@@ -72,6 +72,10 @@ module TextOnlyContentProcessor =
                 ("/uses", "/text/uses/")
                 ("/colophon", "/text/colophon/")
                 ("/tools", "/text/tools/")
+                ("/radio", "/text/radio/")
+                ("/collections/travel-guides/", "/text/collections/travel-guides/")
+                ("/collections/starter-packs/", "/text/collections/starter-packs/")
+                ("/collections", "/text/collections/")
                 ("/contact", "/text/contact/")
                 ("/about", "/text/about/")
                 ("/feed", "/text/feeds/")
@@ -184,6 +188,17 @@ let textOnlyHomepage (recentContent: UnifiedFeedItem list) =
                 li [] [a [_href "/text/feeds/"] [Text "RSS Feeds"]]
                 li [] [a [_href "/text/help/"] [Text "Help & About"]]
                 li [] [a [_href "/"] [Text "Full Website (with graphics)"]]
+            ]
+            
+            h2 [] [Text "Site Pages"]
+            ul [] [
+                li [] [a [_href "/text/uses/"] [Text "Uses"]]
+                li [] [a [_href "/text/colophon/"] [Text "Colophon"]]
+                li [] [a [_href "/text/tools/"] [Text "Tools"]]
+                li [] [a [_href "/text/collections/starter-packs/"] [Text "Starter Packs"]]
+                li [] [a [_href "/text/radio/"] [Text "Online Radio"]]
+                li [] [a [_href "/text/collections/"] [Text "Collections"]]
+                li [] [a [_href "/text/collections/travel-guides/"] [Text "Travel Guides"]]
             ]
         ]
     
@@ -1092,3 +1107,75 @@ let textOnlyToolsPage =
         ]
     
     textOnlyLayout "Tools" (RenderView.AsString.xmlNode contentHtml)
+
+// Online Radio Page
+let textOnlyRadioPage =
+    let markdownHtml = TextOnlyContentProcessor.loadMarkdownContent "radio.md"
+    let processedHtml = 
+        markdownHtml
+        |> TextOnlyContentProcessor.replaceImagesWithText 
+        |> TextOnlyContentProcessor.convertLinksToTextOnly
+    
+    let contentHtml =
+        div [] [
+            p [] [
+                a [_href "/text/"] [Text "← Back to Home"]
+                Text " | "
+                a [_href "/radio"] [Text "View Full Radio Page"]
+            ]
+            
+            // Rendered markdown content with text-only processing
+            div [_class "content"] [
+                rawText processedHtml
+            ]
+        ]
+    
+    textOnlyLayout "Online Radio" (RenderView.AsString.xmlNode contentHtml)
+
+// Collections Hub Page
+let textOnlyCollectionsPage =
+    let markdownHtml = TextOnlyContentProcessor.loadMarkdownContent "collections.md"
+    let processedHtml = 
+        markdownHtml
+        |> TextOnlyContentProcessor.replaceImagesWithText 
+        |> TextOnlyContentProcessor.convertLinksToTextOnly
+    
+    let contentHtml =
+        div [] [
+            p [] [
+                a [_href "/text/"] [Text "← Back to Home"]
+                Text " | "
+                a [_href "/collections"] [Text "View Full Collections Page"]
+            ]
+            
+            // Rendered markdown content with text-only processing
+            div [_class "content"] [
+                rawText processedHtml
+            ]
+        ]
+    
+    textOnlyLayout "Collections" (RenderView.AsString.xmlNode contentHtml)
+
+// Travel Guides Page
+let textOnlyTravelGuidesPage =
+    let markdownHtml = TextOnlyContentProcessor.loadMarkdownContent "travel-guides.md"
+    let processedHtml = 
+        markdownHtml
+        |> TextOnlyContentProcessor.replaceImagesWithText 
+        |> TextOnlyContentProcessor.convertLinksToTextOnly
+    
+    let contentHtml =
+        div [] [
+            p [] [
+                a [_href "/text/"] [Text "← Back to Home"]
+                Text " | "
+                a [_href "/collections/travel-guides"] [Text "View Full Travel Guides Page"]
+            ]
+            
+            // Rendered markdown content with text-only processing
+            div [_class "content"] [
+                rawText processedHtml
+            ]
+        ]
+    
+    textOnlyLayout "Travel Guides" (RenderView.AsString.xmlNode contentHtml)


### PR DESCRIPTION
## Summary

Implements **sections A, B, C of #2418** — adds text-only equivalents for three standalone static-markdown pages that previously had **no `/text/` coverage**, plus a **"Site Pages"** discoverability section on the text-only homepage.

Closes #2418 (A/B/C scope).

## What changed

### New text-only pages (all Pattern X — static markdown re-rendered via the text-only content processor)

| Sec | Page | Source | View / Builder |
|-----|------|--------|----------------|
| A | `/text/radio/` | `_src/radio.md` | `textOnlyRadioPage` / `buildTextOnlyRadioPage` |
| B | `/text/collections/` | `_src/collections.md` | `textOnlyCollectionsPage` / `buildTextOnlyCollectionsPage` |
| C | `/text/collections/travel-guides/` | `_src/travel-guides.md` | `textOnlyTravelGuidesPage` / `buildTextOnlyTravelGuidesPage` |

Each copies the proven `textOnlyColophonPage` / `buildTextOnlyColophonPage` shape exactly.

### Wiring
- All 3 builders called in the `buildTextOnlySite` Phase-1 block.
- **`linkMappings`** additions (exact-href, trailing-slash matched to rendered output):
  - `/radio` → `/text/radio/`
  - `/collections` → `/text/collections/`
  - `/collections/travel-guides/` → `/text/collections/travel-guides/`
  - `/collections/starter-packs/` → `/text/collections/starter-packs/` (bonus: text-only starter-packs existed but was unmapped)
- **Homepage "Site Pages" section** in `textOnlyHomepage` linking Uses, Colophon, Tools, Starter Packs, Radio, Collections, Travel Guides. This fixes pre-existing orphans — none of these standalone pages were linked anywhere in text-only nav before.

## Known acceptable behaviors
- `collections.md` sub-links (blogroll/podroll/youtube/forums/albums/playlists) and `travel-guides.md`'s `chicago-favorites` have **no** text-only equivalent → they remain pointing at the full graphical site (not broken, just not text-only). Out of scope for A/B/C.
- `radio.md` links its playlist as absolute `/radio/OnlineRadioPlaylist.m3u`, which the main build already copies to `_public/radio/` → text-only page needs no m3u copy; the link just resolves.

## Validation
- `dotnet build` — clean (only the expected `FS1104`).
- `dotnet run` — clean site generation.
- All 3 pages render and exist: `radio` 5.6KB, `collections` 3.8KB, `travel-guides` 2.8KB (all well under the 50KB text-only budget).
- Header "View Full … Page" links resolve; radio m3u link points to existing `/radio/OnlineRadioPlaylist.m3u`; homepage "Site Pages" links all resolve.

## Out of scope (tracked separately)
- Remaining #2418 sections (D+) if any.
- Culture-invariant routing sweep → #2420.