### PR TITLE
feat(rsvp): surface RSVP status on cards + dedicated /rsvp page & feed

### DIFF
--- a/Builder.fs
+++ b/Builder.fs
@@ -1389,6 +1389,22 @@ module Builder
         
         printfn "✅ Bookmarks landing page created with %d bookmark responses" bookmarkResponses.Length
 
+    // Generate /rsvp landing page from rsvp-type responses (temporal facet of responses;
+    // detail pages remain at /responses/{file}/, so no URLs move).
+    let buildRsvpLandingPage (responsesFeedData: GenericBuilder.FeedData<Response> list) =
+        let rsvpResponses =
+            responsesFeedData
+            |> List.map (fun item -> item.Content)
+            |> List.filter (fun response -> response.Metadata.ResponseType = "rsvp")
+            |> List.sortByDescending (fun response -> DateTime.Parse(response.Metadata.DatePublished))
+            |> List.toArray
+
+        let rsvpLandingHtml = generate (rsvpView rsvpResponses) "defaultindex" "RSVPs - Luis Quintanilla"
+        let rsvpIndexDir = Path.Join(outputDir, "rsvp")
+        writePageToDir rsvpIndexDir "index.html" rsvpLandingHtml
+
+        printfn "✅ RSVPs landing page created with %d rsvp responses" rsvpResponses.Length
+
     // AST-based media processing using GenericBuilder infrastructure
     let buildMedia() =
         let processor = GenericBuilder.AlbumProcessor.create()

--- a/Builder.fs
+++ b/Builder.fs
@@ -1378,7 +1378,7 @@ module Builder
             responsesFeedData 
             |> List.map (fun item -> item.Content)
             |> List.filter (fun response -> response.Metadata.ResponseType = "bookmark")
-            |> List.sortByDescending (fun response -> DateTime.Parse(response.Metadata.DatePublished))
+            |> List.sortByDescending (fun response -> DateTimeOffset.Parse(response.Metadata.DatePublished))
             |> List.toArray
         
         // Create the bookmarks landing page using bookmarkResponseView (which handles Response arrays but displays as bookmarks)
@@ -1396,7 +1396,7 @@ module Builder
             responsesFeedData
             |> List.map (fun item -> item.Content)
             |> List.filter (fun response -> response.Metadata.ResponseType = "rsvp")
-            |> List.sortByDescending (fun response -> DateTime.Parse(response.Metadata.DatePublished))
+            |> List.sortByDescending (fun response -> DateTimeOffset.Parse(response.Metadata.DatePublished))
             |> List.toArray
 
         let rsvpLandingHtml = generate (rsvpView rsvpResponses) "defaultindex" "RSVPs - Luis Quintanilla"

--- a/ContentTypes.fs
+++ b/ContentTypes.fs
@@ -155,10 +155,16 @@ let urlPrefix (ct: ContentType) =
     | ContentType.AlbumCollection -> "/album-collection/"
     | ContentType.PlaylistCollection -> "/playlist-collection/"
 
-/// String-boundary shim for URL prefixing. Parses the wire string; for response
-/// subtypes / unmapped values it preserves the previous
-/// `| other -> sprintf "/%s/" other` behavior byte-for-byte.
+/// String-boundary shim for URL prefixing. Parses the wire string; response
+/// subtypes carry their subtype as the key but their detail pages live under the
+/// parent route (replies/reshares/stars/rsvps → /responses/, bookmark → /bookmarks/),
+/// matching TimelineViews' initial-content `getProperPermalink`. Any other unmapped
+/// value preserves the previous `| other -> sprintf "/%s/" other` behavior.
 let urlPrefixForKey (contentType: string) =
     match parse contentType with
     | Some ct -> urlPrefix ct
-    | None -> sprintf "/%s/" contentType
+    | None ->
+        match contentType with
+        | Reply | Reshare | Star | Rsvp -> "/responses/"
+        | Bookmark -> "/bookmarks/"
+        | other -> sprintf "/%s/" other

--- a/GenericBuilder.fs
+++ b/GenericBuilder.fs
@@ -895,15 +895,43 @@ module BookProcessor =
 
 /// Response content processor
 module ResponseProcessor =
+    /// RSVP status → (Bootstrap icon class, colour). Mirrors LayoutViews.responsePostView
+    /// so the timeline card matches the individual post page.
+    let private rsvpIconAndColor (status: string) =
+        match status.ToLowerInvariant() with
+        | "yes" -> ("bi bi-check-circle-fill", "#28a745")
+        | "no" -> ("bi bi-x-circle-fill", "#dc3545")
+        | "maybe" -> ("bi bi-question-circle-fill", "#ffc107")
+        | "interested" -> ("bi bi-calendar-check-fill", "#6c757d")
+        | _ -> ("bi bi-calendar-event-fill", "#4a60b6")
+
+    /// The response-target div. For RSVPs it renders a status-aware prefix
+    /// (icon + p-rsvp status + "to" + event link) so the card conveys yes/no/maybe/
+    /// interested. All other response subtypes keep the canonical "→ {url}" form.
+    let private renderResponseTarget (response: Response) =
+        let targetUrl = Html.escapeHtml response.Metadata.TargetUrl
+        match response.Metadata.ResponseType.ToLowerInvariant(), response.Metadata.RsvpStatus with
+        | "rsvp", Some status ->
+            let (iconClass, color) = rsvpIconAndColor status
+            let icon =
+                Html.element "span"
+                    (Html.attribute "class" iconClass + Html.attribute "style" (sprintf "margin-right:5px;color:%s;" color))
+                    ""
+            let statusSpan = Html.element "span" (Html.attribute "class" "p-rsvp") (Html.escapeHtml status)
+            let link = Html.element "a" (Html.attribute "href" targetUrl + Html.attribute "class" "u-in-reply-to") targetUrl
+            Html.element "div" (Html.attribute "class" "response-target")
+                (sprintf "%s%s to %s" icon statusSpan link)
+        | _ ->
+            Html.element "div" (Html.attribute "class" "response-target")
+                (sprintf "→ %s" (Html.element "a" (Html.attribute "href" targetUrl) targetUrl))
+
     /// Chrome-free card body (B2 / F7): the response-target + response-content divs
     /// WITHOUT the <article> wrapper or the <h2><a>title</a></h2> heading. The timeline
     /// composes this directly — its own card-body/title wrapper makes the standalone
     /// CardHtml chrome redundant (historically regex-stripped by `cleanCardHtml`).
     /// `RenderCard` wraps this with the standalone-card chrome, so CardHtml is unchanged.
     let renderResponseCardBody (response: Response) =
-        let targetUrl = Html.escapeHtml response.Metadata.TargetUrl
-        Html.element "div" (Html.attribute "class" "response-target")
-            (sprintf "→ %s" (Html.element "a" (Html.attribute "href" targetUrl) targetUrl)) +
+        renderResponseTarget response +
         Html.element "div" (Html.attribute "class" "response-content") response.Content
 
     /// B2 (RENDER_V2) clean card-body seam. Like renderResponseCardBody, but renders the
@@ -915,13 +943,11 @@ module ResponseProcessor =
     /// renderers, no pipeline.Setup), so the body is byte-identical to response.Content apart
     /// from the intended heading removal.
     let renderResponseCardBodyClean (response: Response) =
-        let targetUrl = Html.escapeHtml response.Metadata.TargetUrl
         let bodyHtml =
             match response.MarkdownSource with
             | Some raw -> ASTParsing.renderCardHtmlFromMarkdown (ASTParsing.stripFrontMatter raw)
             | None -> response.Content
-        Html.element "div" (Html.attribute "class" "response-target")
-            (sprintf "→ %s" (Html.element "a" (Html.attribute "href" targetUrl) targetUrl)) +
+        renderResponseTarget response +
         Html.element "div" (Html.attribute "class" "response-content") bodyHtml
 
     let create() : ContentProcessor<Response> = {

--- a/Program.fs
+++ b/Program.fs
@@ -71,6 +71,9 @@ let main argv =
     
     // Create bookmarks landing page using the bookmarks data
     buildBookmarksLandingPage bookmarksFeedData
+
+    // Create RSVPs landing page from rsvp-type responses
+    buildRsvpLandingPage responsesFeedData
     
     let snippetsFeedData = buildSnippets()
     let wikisFeedData = buildWikis()

--- a/UnifiedFeeds.fs
+++ b/UnifiedFeeds.fs
@@ -334,6 +334,13 @@ module UnifiedFeeds
                 OutputPath = "bookmarks/feed.xml"
                 ContentType = Some ContentTypes.Bookmarks
             })
+            (ContentTypes.Rsvp, {
+                Title = "Luis Quintanilla - RSVPs"
+                Link = "https://www.lqdev.me/rsvp"
+                Description = "Events Luis Quintanilla has responded to (yes/no/maybe/interested)"
+                OutputPath = "rsvp/feed.xml"
+                ContentType = Some ContentTypes.Rsvp
+            })
             (ContentTypes.Snippets, {
                 Title = "Luis Quintanilla - Snippets"
                 Link = "https://www.lqdev.me/resources/snippets"
@@ -399,13 +406,13 @@ module UnifiedFeeds
                 allUnifiedItems 
                 |> List.filter (fun item -> 
                     if contentType = ContentTypes.Responses then
-                        // For responses feed, include all response subtypes
-                        [ ContentTypes.Star; ContentTypes.Reply; ContentTypes.Reshare; ContentTypes.Responses ] |> List.contains item.ContentType
+                        // For responses feed, include all response subtypes (incl. rsvp)
+                        [ ContentTypes.Star; ContentTypes.Reply; ContentTypes.Reshare; ContentTypes.Rsvp; ContentTypes.Responses ] |> List.contains item.ContentType
                     else
                         item.ContentType = contentType)
                 |> List.take (min 20 (allUnifiedItems |> List.filter (fun item -> 
                     if contentType = ContentTypes.Responses then
-                        [ ContentTypes.Star; ContentTypes.Reply; ContentTypes.Reshare; ContentTypes.Responses ] |> List.contains item.ContentType
+                        [ ContentTypes.Star; ContentTypes.Reply; ContentTypes.Reshare; ContentTypes.Rsvp; ContentTypes.Responses ] |> List.contains item.ContentType
                     else
                         item.ContentType = contentType) |> List.length))
             

--- a/Views/CollectionViews.fs
+++ b/Views/CollectionViews.fs
@@ -57,6 +57,19 @@ let notesView (posts: Post array) =
         ]
     ]
 
+let private responseSubtypeLabel (r: Response) =
+    match r.Metadata.ResponseType.ToLowerInvariant() with
+    | "reply" -> "Reply"
+    | "reshare" | "share" -> "Reshare"
+    | "star" -> "Star"
+    | "bookmark" -> "Bookmark"
+    | "rsvp" ->
+        match r.Metadata.RsvpStatus with
+        | Some s when s.Length > 0 -> sprintf "RSVP: %c%s" (Char.ToUpper s.[0]) (s.Substring(1))
+        | _ -> "RSVP"
+    | other when other.Length > 0 -> sprintf "%c%s" (Char.ToUpper other.[0]) (other.Substring(1))
+    | _ -> "Response"
+
 let responseView (posts: Response array) =
     div [ _class "d-grip gap-3" ] [
         h2[] [Text "Responses"]
@@ -65,6 +78,8 @@ let responseView (posts: Response array) =
             for post in posts do
                 li [] [
                     a [ _href $"/responses/{post.FileName}"] [ Text post.Metadata.Title ]
+                    Text " — "
+                    span [ _class "response-subtype" ] [ Text (responseSubtypeLabel post) ]
                     Text " • "
                     Text (DateTimeOffset.Parse(post.Metadata.DatePublished).ToString("MMM dd, yyyy"))
                 ]
@@ -99,6 +114,24 @@ let bookmarkResponseView (posts: Response array) =
                 ]
         ]
     ]    
+
+// View for RSVP responses (Response objects with rsvp type) — a temporal facet of
+// responses, mirroring the bookmarks landing page. Detail pages stay at /responses/{file}/.
+let rsvpView (posts: Response array) =
+    div [ _class "d-grip gap-3" ] [
+        h2[] [Text "RSVPs"]
+        p [] [Text "Events I've responded to — yes, no, maybe, or interested"]
+        ul [] [
+            for post in posts do
+                li [] [
+                    a [ _href $"/responses/{post.FileName}"] [ Text post.Metadata.Title ]
+                    Text " — "
+                    span [ _class "response-subtype" ] [ Text (responseSubtypeLabel post) ]
+                    Text " • "
+                    Text (DateTimeOffset.Parse(post.Metadata.DatePublished).ToString("MMM dd, yyyy"))
+                ]
+        ]
+    ]
 
 let libraryView (books:Book array) = 
     div [ _class "d-grip gap-3" ] [
@@ -469,6 +502,15 @@ let enhancedSubscriptionHubView (items: UnifiedFeeds.UnifiedFeedItem array) =
                 Text "Feed URL: "
                 a [ _href "/bookmarks.rss" ] [ Text "/bookmarks.rss" ]
                 Text " (filter by bookmark type)"
+            ]
+            
+            // RSVPs Feed
+            h3 [] [ a [ _href "/rsvp/" ] [ Text "RSVPs" ] ]
+            p [] [ Text "Events I've responded to — yes, no, maybe, or interested." ]
+            p [] [
+                Text "Feed URL: "
+                a [ _href "/rsvp.rss" ] [ Text "/rsvp.rss" ]
+                Text " (RSVP responses only)"
             ]
             
             // Media Feed  

--- a/Views/Partials.fs
+++ b/Views/Partials.fs
@@ -54,6 +54,7 @@ let notesView = CollectionViews.notesView
 let responseView = CollectionViews.responseView
 let bookmarkView = CollectionViews.bookmarkView
 let bookmarkResponseView = CollectionViews.bookmarkResponseView
+let rsvpView = CollectionViews.rsvpView
 let libraryView = CollectionViews.libraryView
 let snippetsView = CollectionViews.snippetsView
 let wikisView = CollectionViews.wikisView

--- a/Views/TimelineViews.fs
+++ b/Views/TimelineViews.fs
@@ -31,6 +31,7 @@ type ProgressiveContentItem =
       date: string
       url: string
       content: string
+      rsvpStatus: string
       tags: string[] }
 
 /// Extract item type from review content for badge display
@@ -255,7 +256,11 @@ let timelineHomeViewStratified (initialItems: UnifiedFeeds.UnifiedFeedItem array
                                           | "star" -> "Star"
                                           | "reply" -> "Reply"
                                           | "reshare" -> "Reshare"
-                                          | "rsvp" -> "RSVP"
+                                          | "rsvp" ->
+                                              // Surface the attendance status on the badge (e.g. "RSVP · Yes")
+                                              (match item.RsvpStatus with
+                                               | Some s when s.Length > 0 -> sprintf "RSVP · %c%s" (System.Char.ToUpper(s.[0])) (s.Substring(1))
+                                               | _ -> "RSVP")
                                           | "bookmark" -> "Bookmark"
                                           | "ai-memex" -> "AI Memex"
                                           | _ -> item.ContentType)
@@ -308,6 +313,7 @@ let timelineHomeViewStratified (initialItems: UnifiedFeeds.UnifiedFeedItem array
                                   date = item.Date
                                   url = properPermalink
                                   content = item.BodyHtml.Value
+                                  rsvpStatus = (match item.RsvpStatus with Some s -> s | None -> "")
                                   tags = item.Tags })
                             |> List.toArray
                             |> JsonSerializer.Serialize

--- a/_src/js/timeline.js
+++ b/_src/js/timeline.js
@@ -432,7 +432,13 @@ const TimelineProgressiveLoader = {
                 const itemType = this.extractReviewItemType(item.content);
                 return itemType || 'Review';  // Fallback to generic "Review"
             }
-            
+
+            if (item.contentType === 'rsvp') {
+                // Surface the attendance status on the badge (e.g. "RSVP · Yes")
+                const s = item.rsvpStatus;
+                return s ? `RSVP · ${s.charAt(0).toUpperCase()}${s.slice(1)}` : 'RSVP';
+            }
+
             // For other content types, use the standard mapping
             return {
                 'posts': 'Blog Post',
@@ -449,6 +455,7 @@ const TimelineProgressiveLoader = {
                 'star': 'Star',
                 'reply': 'Reply',
                 'reshare': 'Reshare',
+                'rsvp': 'RSVP',
                 'bookmark': 'Bookmark'
             }[item.contentType] || item.contentType;
         })();

--- a/_src/resources/ai-memex/pattern-dual-render-path-drift.md
+++ b/_src/resources/ai-memex/pattern-dual-render-path-drift.md
@@ -1,0 +1,126 @@
+---
+title: "Pattern: One Surface, Two Renderers — Drift Across the Server/Client Progressive-Loading Boundary"
+description: "When a single view is drawn by a server-side renderer for its initial window and a client-side renderer for progressively-loaded items, every derived value (badge, URL) gets computed twice and silently drifts — and recency decides which path draws an item, so a server-only fix never fires for older content."
+entry_type: pattern
+published_date: "2026-06-16 10:37 -05:00"
+last_updated_date: "2026-06-16 10:37 -05:00"
+tags: "fsharp, javascript, web, architecture, performance, patterns, lqdev-me"
+related_skill: "write-ai-memex"
+source_project: "lqdev-me"
+related_entries: pattern-progressive-loading, pattern-content-type-taxonomy-mismatch, pattern-closed-du-identity-vs-wire-boundary, pattern-response-type-badge-specificity
+---
+
+## Discovery
+
+RSVP cards on the homepage timeline showed a generic `rsvp` badge with no attendance
+status — you couldn't tell *yes* from *maybe* from a card, only by opening the detail page
+(which correctly shows `✅ yes to {url}`). While fixing it, two things were surprising:
+
+1. **A server-side fix looked correct in review but never fired.** I first enriched the
+   initial-card badge in `Views/TimelineViews.fs` to render `RSVP · {Status}`. The code was
+   right, the build was clean — and the actual RSVP cards on the live homepage still showed a
+   raw lowercase `rsvp`. The existing RSVPs are from January 2026; they fall *outside* the
+   server-rendered initial window, so that code path is never exercised for them.
+
+2. **The same value was being derived in two places that disagreed.** The badge label and the
+   permalink for a timeline card are each computed *once in F#* (for the initial cards) and
+   *again in JavaScript* (for progressively-loaded cards). The two derivations had drifted: the
+   JS badge map had no `rsvp` case (so it printed the raw key), and a separate progressive-link
+   URL shim routed response subtypes to `/rsvp/{file}/` instead of `/responses/{file}/`.
+
+## Root Cause
+
+The homepage timeline is **one logical surface drawn by two physically separate renderers**, a
+direct consequence of the [[pattern-progressive-loading|progressive-loading]] architecture:
+
+- **Server path** — `Views/TimelineViews.fs` renders roughly the first ~50 cards as static HTML
+  at build time (badge match + `getProperPermalink`, `TimelineViews.fs:201`).
+- **Client path** — the remaining items are emitted as `remainingContentData-{key}` JSON
+  `<script>` blocks and rendered in the browser by `_src/js/timeline.js` (`createCard`, with its
+  own `contentTypeBadge` map and its own URL construction).
+
+Three independent traps fall out of this split:
+
+1. **Recency decides the dispatch.** Whether an item is drawn by F# or by JS depends purely on
+   how recent it is. Old content (Jan-2026 RSVPs) renders *only* via the JS path. So a fix to the
+   server renderer is invisible for exactly the content that motivated the bug report — and a
+   quick local check on a freshly-authored item would render server-side and *mask* the defect.
+
+2. **Duplicated derivation drifts.** The badge label and the permalink are each derived twice —
+   once server-side, once client-side — with no shared source of truth. Response subtypes
+   (`reply`/`reshare`/`star`/`rsvp`) flow through both as the wire `contentType`
+   (see [[pattern-closed-du-identity-vs-wire-boundary]]), and the two derivations had silently
+   diverged:
+   - **Badge:** `TimelineViews.fs` had a match arm; `timeline.js`'s badge object had no `rsvp`
+     key → fell through to the raw string.
+   - **URL:** `getProperPermalink` (`TimelineViews.fs:214`) correctly mapped
+     `star|reply|reshare|rsvp → /responses/`, but the progressive serializer
+     (`TimelineViews.fs:310`) built links via `ContentTypes.urlPrefixForKey`, whose `parse`
+     returns `None` for subtypes, leaving the `| other -> sprintf "/%s/" other` fallback to emit
+     `/rsvp/`, `/star/`, etc. Two functions answering "what's the URL prefix for this key?"
+     gave different answers.
+
+3. **The client can only render what the JSON carries.** Even with a correct JS badge, the
+   browser cannot show RSVP status unless that status crosses the boundary. The serialized record
+   `ProgressiveContentItem` (`TimelineViews.fs:28`) carried `title/contentType/date/url/content/
+   tags` but **not** `rsvpStatus` — so the data needed for the fix simply wasn't on the wire.
+
+## Solution
+
+Treat the **JSON record as the contract** between the two renderers, and make the client path
+mirror the server path for every value it must show.
+
+1. **Thread the missing field through the wire record** (plain `string`, empty = none — STJ
+   serializes F# `option` poorly without FSharp.SystemTextJson; see
+   [[pattern-stj-private-record-empty-object]]):
+   ```fsharp
+   type ProgressiveContentItem =
+       { title: string; contentType: string; date: string
+         url: string; content: string; rsvpStatus: string; tags: string[] }
+   // ...
+   rsvpStatus = (match item.RsvpStatus with Some s -> s | None -> "")
+   ```
+
+2. **Give the JS renderer the same case the F# renderer has:**
+   ```javascript
+   if (item.contentType === 'rsvp') {
+       const s = item.rsvpStatus;
+       return s ? `RSVP · ${s.charAt(0).toUpperCase()}${s.slice(1)}` : 'RSVP';
+   }
+   ```
+
+3. **Reconcile the two URL derivations.** Make `urlPrefixForKey` agree with `getProperPermalink`
+   for subtypes instead of relying on the `/%s/` fallback (`ContentTypes.fs:163`):
+   ```fsharp
+   | None ->
+       match contentType with
+       | Reply | Reshare | Star | Rsvp -> "/responses/"
+       | Bookmark -> "/bookmarks/"
+       | other -> sprintf "/%s/" other
+   ```
+
+4. **Verify against the generated artifact *and* old content**, not a fresh item: confirm
+   `"contentType":"rsvp"..."rsvpStatus":"maybe"` is present in `_public/index.html`, that the
+   deployed `_public/assets/js/timeline.js` is byte-identical to source (MD5), and that the
+   progressive RSVP links resolve to `/responses/...`.
+
+## Prevention
+
+- **A "single view" with progressive loading is two renderers; enumerate every derived value and
+  confirm both paths compute it identically.** Badges, permalinks, date formatting, icons — each
+  is a drift candidate. The durable fix is a *shared source of truth* (derive server-side, ship
+  the rendered value or a small enum in the JSON, let the client only display); short of that,
+  every server-side branch needs a mirrored client-side branch.
+- **Recency-dependent dispatch hides bugs from the obvious test.** When the renderer is chosen by
+  position-in-feed, always reproduce on the actual *old* item that triggered the report. A
+  freshly-authored test item renders down the server path and will pass while the real content
+  stays broken.
+- **The client can only show what the wire record carries.** Before touching client rendering,
+  check the serialized contract first — a missing field is an upstream fix, not a JS fix.
+- **Two functions named "the URL/badge/prefix for this key" are a coupling hazard.** Here
+  `getProperPermalink` and `urlPrefixForKey` independently encoded the same subtype→route table;
+  one was right and one had a latent `/%s/` fallback that only became a *live* bug once subtypes
+  flowed through it into emitted links. Collapse such pairs to one function, or assert they agree.
+- **Diagnose generator bugs from `_public/`, not the source.** As with the sibling
+  [[pattern-content-type-taxonomy-mismatch]], the F# compiled cleanly and the source looked
+  fine; the defect was only visible in the emitted HTML/JSON and the deployed JS asset.

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -161,6 +161,11 @@
       "statusCode": 301
     },
     {
+      "route": "/rsvp.rss",
+      "redirect": "/rsvp/feed.xml",
+      "statusCode": 301
+    },
+    {
       "route": "/ai-memex.rss",
       "redirect": "/resources/ai-memex/feed.xml",
       "statusCode": 301


### PR DESCRIPTION
## Summary

Makes RSVP responses readable in the timeline and adds a first-class `/rsvp` surface — **without moving any existing URLs** (RSVP detail pages stay at `/responses/{file}/`).

### Problem
- Timeline RSVP cards showed a generic `rsvp` badge + `-> {url}`; you couldn't tell *yes / no / maybe / interested* without opening the post.
- No top-level RSVP surface (`/rsvp` 404'd, no `/rsvp.rss`).
- Latent bug: RSVPs were excluded from `/responses/feed.xml`.

### Changes
**Cards & timeline**
- Status-aware card body: status icon + `{status} to {link}` with proper microformats (`p-rsvp` + `u-in-reply-to`), mirroring the detail page.
- Both render paths now badge `RSVP - {Status}`: server-side initial cards (`TimelineViews.fs`) **and** client-side progressive cards (threaded `rsvpStatus` through the `ProgressiveContentItem` JSON record + added the `rsvp` case to `_src/js/timeline.js`).

**Responses list**
- `/responses/` now labels every subtype (Reply / Reshare / Star / RSVP + status).

**New `/rsvp` surface** (temporal facet, mirrors `/bookmarks`)
- `/rsvp` landing page (`buildRsvpLandingPage`), `/rsvp/feed.xml`, and `/rsvp.rss` alias.
- Surfaced on the subscribe hub.

**Fixes**
- Added `Rsvp` to the responses-feed subtype filter (`UnifiedFeeds.fs`) so RSVPs appear in `/responses/feed.xml`.
- Fixed `urlPrefixForKey` routing response subtypes to `/rsvp/`, `/star/`, etc. instead of `/responses/` (progressive-link routing bug); now agrees with `getProperPermalink`.

**Docs**
- AI Memex `pattern` entry: `pattern-dual-render-path-drift.md` documenting the one-surface/two-renderers drift gotcha.

### Validation
- `dotnet build` + `dotnet run` clean; site regenerates (1770 items).
- `/rsvp/index.html`, `/rsvp/feed.xml`, `/rsvp.rss` present; RSVP feed has the expected items.
- Progressive JSON carries `rsvpStatus` (`maybe`, `yes`); deployed `timeline.js` is MD5-identical to source; badge renders `RSVP - Maybe/Yes`.
- `/responses/` labels verified (Reply/Reshare/Star/RSVP+status); RSVP detail URLs unchanged.

### Deferred
- iCal (`.ics`) export — needs a richer RSVP model with event dates (current data has none). Documented in the Memex entry / plan.

### Note
Supersedes the intent of the stale draft #680 (older approach using `/rsvps/` and the orphaned `RsvpData` renderer); this PR takes the lean frontmatter-based path instead.